### PR TITLE
feat(packages): atualização dos pacotes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,7 @@
   "tabWidth": 2,
   "semi": true,
   "bracketSpacing": true,
-  "quoteProps": "preserve"
+  "quoteProps": "preserve",
+  "arrowParens": "avoid",
+  "trailingComma": "none"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "10.9.0"
+ - "10.16.3"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-angular": "^8.3.4",
     "@commitlint/travis-cli": "^8.3.5",
-    "autoprefixer": "^9.7.4",
+    "autoprefixer": "^9.7.5",
     "cssnano": "^4.1.10",
     "del": "^5.1.0",
     "gulp": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard-version": "^7.1.0",
     "xml2js": "^0.4.23",
     "yargs": "^15.3.1",
-    "prettier": "1.19.1",
+    "prettier": "2.0.2",
     "pretty-quick": "^2.0.1"
   },
   "standard-version": {

--- a/src/app/js/app.js
+++ b/src/app/js/app.js
@@ -3,7 +3,7 @@ var menuElement = document.querySelector('.po-menu');
 var titleElement = document.querySelector('.po-cdn-app-content > header > h1');
 var routerContentElement = document.querySelector('.router-content');
 
-request('./components.json', function(response) {
+request('./components.json', function (response) {
   setToolbarTitle();
 
   createMenu(JSON.parse(response));
@@ -33,7 +33,7 @@ function loadInitialPage() {
   window.location.search
     .replace('?', '') // Remove o "?" do ínicio dos query parameters
     .split('&') // Separa os parametros
-    .forEach(function(param) {
+    .forEach(function (param) {
       var name = param.split('=')[0];
       var value = param.split('=')[1];
 
@@ -203,7 +203,7 @@ function execScript(url) {
 function request(url, success) {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', url);
-  xhr.onload = function() {
+  xhr.onload = function () {
     if (xhr.status === 200) {
       success(xhr.responseText);
     } else {

--- a/src/css/components/po-field/po-lookup/po-lookup.html
+++ b/src/css/components/po-field/po-lookup/po-lookup.html
@@ -122,7 +122,7 @@
             <input type="text" class="po-input po-input-icon-right" value="PO" disabled />
             <div class="po-field-icon-container-right">
               <span
-                class="po-icon  po-field-icon-disabled po-icon-search"
+                class="po-icon po-field-icon-disabled po-icon-search"
                 onClick="document.getElementById('table').classList.remove('po-invisible');"
               ></span>
             </div>
@@ -553,7 +553,7 @@
                             </tbody>
                             <tbody class="po-table-group-row">
                               <tr class="po-table-row">
-                                <td class="po-table-column po-table-column-selectable ">
+                                <td class="po-table-column po-table-column-selectable">
                                   <input type="radio" id="radio3" class="po-radio-group-input" />
                                   <label class="po-radio-group-label po-clickable" for="radio3"></label>
                                 </td>

--- a/src/css/components/po-field/po-rich-text/po-rich-text.html
+++ b/src/css/components/po-field/po-rich-text/po-rich-text.html
@@ -1302,7 +1302,7 @@
     <!-- PO-RICH-TEXT - Início -->
     <div class="po-rich-text">
       <!-- PO-RICH-TEXT-BODY - Início -->
-      <div class="po-rich-text-body po-text-left" style="height: 200px" data-placeholder="">
+      <div class="po-rich-text-body po-text-left" style="height: 200px;" data-placeholder="">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac justo a felis dapibus scelerisque eget non
           risus. Phasellus laoreet tincidunt dictum. Proin tempor semper sapien sit amet accumsan. Pellentesque
@@ -1520,7 +1520,7 @@
 </div>
 
 <!-- MODAL EM MODO DE ABERTURA -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -1540,7 +1540,7 @@
           <div class="po-modal-body">
             <div class="po-row">
               <div class="po-md-12">
-                <div class="po-upload-drag-drop-area" style="height: 160px">
+                <div class="po-upload-drag-drop-area" style="height: 160px;">
                   <div class="po-upload-drag-drop-area-container">
                     <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
                     <div class="po-upload-drag-drop-area-label">Arraste os arquivos aqui</div>
@@ -1595,7 +1595,7 @@
 </div>
 
 <!-- MODAL COM UPLOAD -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -1615,7 +1615,7 @@
           <div class="po-modal-body">
             <div class="thf-row">
               <div class="po-md-12">
-                <div class="po-upload-drag-drop-area" style="height: 160px">
+                <div class="po-upload-drag-drop-area" style="height: 160px;">
                   <div class="po-upload-drag-drop-area-container">
                     <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
                     <div class="po-upload-drag-drop-area-label">Arraste os arquivos aqui</div>

--- a/src/css/components/po-loading-overlay/po-loading-overlay.html
+++ b/src/css/components/po-loading-overlay/po-loading-overlay.html
@@ -156,7 +156,7 @@
       </div>
     </div>
 
-    <div class="po-overlay-fixed" style="display:none;">
+    <div class="po-overlay-fixed" style="display: none;">
       <a
         class="turnoff-overlay"
         tabindex="0"

--- a/src/css/components/po-menu/po-menu.html
+++ b/src/css/components/po-menu/po-menu.html
@@ -162,7 +162,7 @@
                   Games (1º nível)
                 </div>
                 <!-- max height alterado por meio de javascript para criar animação -->
-                <div class="po-menu-sub-items" style="max-height:704px">
+                <div class="po-menu-sub-items" style="max-height: 704px;">
                   <div>
                     <div class="po-menu-item po-menu-item-level-two">
                       GTA
@@ -182,7 +182,7 @@
                         Star Wars (2º nível)
                       </div>
                       <!-- max height alterado por meio de javascript para criar animação -->
-                      <div class="po-menu-sub-items" style="max-height:192px">
+                      <div class="po-menu-sub-items" style="max-height: 192px;">
                         <div>
                           <div class="po-menu-item po-menu-item-grouper-down po-clickable po-menu-item-level-three">
                             <span class="po-icon po-icon-arrow-down po-menu-group-icon"></span>
@@ -203,7 +203,7 @@
                             Playstation 4 (3º nível)
                           </div>
                           <!-- max height alterado por meio de javascript para criar animação -->
-                          <div class="po-menu-sub-items" style="max-height:192px">
+                          <div class="po-menu-sub-items" style="max-height: 192px;">
                             <div>
                               <a href="#" class="po-menu-item-link">
                                 <div class="po-menu-item po-menu-item-level-four">
@@ -320,7 +320,7 @@
                   <span class="po-icon po-icon-arrow-up po-menu-group-icon"></span>
                 </div>
                 <!-- max height alterado por meio de javascript para criar animação -->
-                <div class="po-menu-sub-items" style="max-height:256px">
+                <div class="po-menu-sub-items" style="max-height: 256px;">
                   <div>
                     <a href="#" class="po-menu-item-link">
                       <div class="po-menu-item po-menu-item-level-two">Agendamento de férias</div>
@@ -439,7 +439,7 @@
                   Games (1º nível)
                 </div>
                 <!-- max height alterado por meio de javascript para criar animação -->
-                <div class="po-menu-sub-items" style="max-height:704px">
+                <div class="po-menu-sub-items" style="max-height: 704px;">
                   <div>
                     <div class="po-menu-item po-menu-item-level-two">
                       <div class="po-menu-badge-align">
@@ -464,7 +464,7 @@
                         Star Wars (2º nível)
                       </div>
                       <!-- max height alterado por meio de javascript para criar animação -->
-                      <div class="po-menu-sub-items" style="max-height:192px">
+                      <div class="po-menu-sub-items" style="max-height: 192px;">
                         <div>
                           <div class="po-menu-item po-menu-item-grouper-down po-clickable po-menu-item-level-three">
                             <span class="po-icon po-icon-arrow-down po-menu-group-icon"></span>
@@ -485,7 +485,7 @@
                             Playstation 4 (3º nível)
                           </div>
                           <!-- max height alterado por meio de javascript para criar animação -->
-                          <div class="po-menu-sub-items" style="max-height:192px">
+                          <div class="po-menu-sub-items" style="max-height: 192px;">
                             <div>
                               <a href="#" class="po-menu-item-link">
                                 <div class="po-menu-item po-menu-item-level-four">
@@ -575,7 +575,7 @@
           <div class="po-menu-item-wrapper">
             <div class="po-menu-item-first">
               <div class="po-menu-icon-container po-menu-item-no-data">
-                <span class="po-icon po-icon-info po-menu-icon-item "></span>
+                <span class="po-icon po-icon-info po-menu-icon-item"></span>
                 <div class="po-menu-icon-label">Item não encontrado.</div>
               </div>
             </div>
@@ -1025,7 +1025,7 @@
                   Games (1º nível)
                 </div>
                 <!-- max height alterado por meio de javascript para criar animação -->
-                <div class="po-menu-sub-items" style="max-height:704px">
+                <div class="po-menu-sub-items" style="max-height: 704px;">
                   <div>
                     <div class="po-menu-item po-menu-item-level-two">
                       <div class="po-menu-badge-align">
@@ -1050,7 +1050,7 @@
                         Star Wars (2º nível)
                       </div>
                       <!-- max height alterado por meio de javascript para criar animação -->
-                      <div class="po-menu-sub-items" style="max-height:192px">
+                      <div class="po-menu-sub-items" style="max-height: 192px;">
                         <div>
                           <div class="po-menu-item po-menu-item-grouper-down po-clickable po-menu-item-level-three">
                             <span class="po-icon po-icon-arrow-down po-menu-group-icon"></span>
@@ -1071,7 +1071,7 @@
                             Playstation 4 (3º nível)
                           </div>
                           <!-- max height alterado por meio de javascript para criar animação -->
-                          <div class="po-menu-sub-items" style="max-height:192px">
+                          <div class="po-menu-sub-items" style="max-height: 192px;">
                             <div>
                               <a href="#" class="po-menu-item-link">
                                 <div class="po-menu-item po-menu-item-level-four">

--- a/src/css/components/po-modal/po-modal.html
+++ b/src/css/components/po-modal/po-modal.html
@@ -151,7 +151,7 @@
 </div>
 
 <!-- MODAL PEQUENA -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -198,7 +198,7 @@
 </div>
 
 <!-- MODAL MÉDIA -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -245,7 +245,7 @@
 </div>
 
 <!-- MODAL GRANDE -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -292,7 +292,7 @@
 </div>
 
 <!-- MODAL EXTRA GRANDE -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -339,7 +339,7 @@
 </div>
 
 <!-- MODAL COM TAMANHO AUTOMATICO -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -386,7 +386,7 @@
 </div>
 
 <!-- MODAL EXTRA GRANDE -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -424,7 +424,7 @@
 </div>
 
 <!-- MODAL COM TAMANHO AUTOMATICO COM 1 BOTÃO-->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -462,7 +462,7 @@
 </div>
 
 <!-- MODAL COM BASTANTE CONTEÚDO -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -556,7 +556,7 @@
 </div>
 
 <!-- MODAL COM TÍTULO EXTENSO COM ELLIPSE -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -595,7 +595,7 @@
 </div>
 
 <!-- MODAL DISABLED ACTION -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -632,7 +632,7 @@
 </div>
 
 <!-- MODAL LOADING ACTION  -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -681,7 +681,7 @@
 </div>
 
 <!-- MODAL DISABLED -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -718,7 +718,7 @@
 </div>
 
 <!-- MODAL DISABLED AND LOADING ACTION -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">
@@ -756,7 +756,7 @@
 </div>
 
 <!-- MODAL AUTOMÁTICA COM BASTANTE CONTEÚDO -->
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">

--- a/src/css/components/po-page/po-modal-password-recovery/po-modal-password-recovery.html
+++ b/src/css/components/po-page/po-modal-password-recovery/po-modal-password-recovery.html
@@ -93,7 +93,7 @@
 
 <!-- Modal de e-mail -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -171,7 +171,7 @@
 
 <!-- Modal de e-mail contendo mensagem de erro -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -255,7 +255,7 @@
 
 <!-- Modal de e-mail com link para e-mail de suporte -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -340,7 +340,7 @@
 
 <!-- Modal de e-mail com campo para digitação de número de telefone -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -418,7 +418,7 @@
 
 <!-- Modal contendo radio group e campo para e-mail -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -518,7 +518,7 @@
 
 <!-- Modal contendo radio group e campo para número de telefone -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">
@@ -617,7 +617,7 @@
 
 <!-- Modal de digitação e envio de código SMS -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-pb-2 po-pt-2">
         <div class="po-modal-vertical-align">
@@ -688,7 +688,7 @@
 
 <!-- Modal de digitação e envio de código SMS e mensagem de erro concatenada com e-mail de contato -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-pb-2 po-pt-2">
         <div class="po-modal-vertical-align">
@@ -766,7 +766,7 @@
 
 <!-- Modal de confirmação -->
 <po-modal-password-recovery>
-  <div class="po-modal" tabindex="0" style="display:none;">
+  <div class="po-modal" tabindex="0" style="display: none;">
     <div class="po-modal-overlay">
       <div class="po-modal-container po-p-2">
         <div class="po-modal-vertical-align">

--- a/src/css/components/po-page/po-page-blocked-user/po-page-blocked-user.html
+++ b/src/css/components/po-page/po-page-blocked-user/po-page-blocked-user.html
@@ -56,7 +56,7 @@
                     <div class="po-page-blocked-user-contact-item po-page-blocked-user-contact-mail po-md-6">
                       <a class="po-page-blocked-user-link po-clickable" href="#" target="_self">
                         <div class="po-page-blocked-user-contact-group-item">
-                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1 "></span>
+                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
                           <span class="po-page-blocked-user-contact-text po-clickable po-font-text">
                             ti@empresa.com.br
                           </span>
@@ -125,7 +125,7 @@
                     <div class="po-page-blocked-user-contact-item po-page-blocked-user-contact-mail po-md-6">
                       <a class="po-page-blocked-user-link po-clickable" href="mailto" target="_self">
                         <div class="po-page-blocked-user-contact-group-item">
-                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1 "></span>
+                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
                           <span class="po-page-blocked-user-contact-text po-clickable po-font-text">
                             ti@empresa.com.br
                           </span>
@@ -196,7 +196,7 @@
                     <div class="po-page-blocked-user-contact-item po-page-blocked-user-contact-mail po-md-6">
                       <a class="po-page-blocked-user-link po-clickable" href="mailto" target="_self">
                         <div class="po-page-blocked-user-contact-group-item">
-                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1 "></span>
+                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
                           <span class="po-page-blocked-user-contact-text po-clickable po-font-text">
                             ti@empresa.com.br
                           </span>
@@ -272,7 +272,7 @@
                         target="_self"
                       >
                         <div class="po-page-blocked-user-contact-group-item">
-                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1 "></span>
+                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
                           <span class="po-page-blocked-user-contact-text po-font-text">
                             usuario.nome.sobrenome@empresa.com.br
                           </span>
@@ -338,7 +338,7 @@
                         target="_self"
                       >
                         <div class="po-page-blocked-user-contact-group-item">
-                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1 "></span>
+                          <span class="po-page-blocked-user-contact-icon po-icon po-icon-mail po-pr-1"></span>
                           <span class="po-page-blocked-user-contact-text po-clickable po-font-text">
                             usuario.nome.sobrenome.sample.excedente.de.caracteres@empresa.com.br
                           </span>

--- a/src/css/components/po-page/po-page-change-password/po-page-change-password.html
+++ b/src/css/components/po-page/po-page-change-password/po-page-change-password.html
@@ -782,7 +782,7 @@
     <br />
     <h4>Po Page Change Password com mensagem de senha alterada com sucesso.</h4>
     <br />
-    <div class="container-relative" style="position:relative">
+    <div class="container-relative" style="position: relative;">
       <div class="po-overlay-absolute">
         <div class="po-modal-container po-p-2">
           <div class="po-modal-vertical-align">

--- a/src/css/components/po-page/po-page-list/po-dynamic-advanced-filter/po-dynamic-advanced-filter.html
+++ b/src/css/components/po-page/po-page-list/po-dynamic-advanced-filter/po-dynamic-advanced-filter.html
@@ -10,7 +10,7 @@
   </div>
 </div>
 
-<div class="po-modal" style="display:none;">
+<div class="po-modal" style="display: none;">
   <div class="po-modal-overlay">
     <div class="po-modal-container po-p-2">
       <div class="po-modal-vertical-align">

--- a/src/css/components/po-page/po-page-login/po-page-login.html
+++ b/src/css/components/po-page/po-page-login/po-page-login.html
@@ -657,7 +657,7 @@
                         <div class="po-field-container-bottom"></div>
                       </div>
                     </div>
-                    <div class="po-page-login-info-icon-container" style="position:relative">
+                    <div class="po-page-login-info-icon-container" style="position: relative;">
                       <span class="po-icon po-field-icon po-icon-info"> </span>
                       <div class="po-tooltip">
                         <div class="po-tooltip-arrow po-arrow-left"></div>

--- a/src/css/components/po-popup/po-popup.html
+++ b/src/css/components/po-popup/po-popup.html
@@ -63,7 +63,7 @@
   <section>
     <h5>Itens do popup desabilitados:</h5>
 
-    <div class="po-popup ">
+    <div class="po-popup">
       <div class="po-popup-arrow po-arrow-top-right"></div>
 
       <div class="po-popup-item-default po-popup-item-disabled">
@@ -119,7 +119,7 @@
   <section>
     <h5>Item selecionado:</h5>
 
-    <div class="po-popup ">
+    <div class="po-popup">
       <div class="po-popup-arrow po-arrow-top-right"></div>
 
       <div class="po-popup-item-default">

--- a/src/css/components/po-progress/po-progress.html
+++ b/src/css/components/po-progress/po-progress.html
@@ -63,7 +63,7 @@
       </label>
 
       <div class="po-progress-bar">
-        <div class="po-progress-bar-element po-progress-bar-primary" style="transform: scaleX(0.50);"></div>
+        <div class="po-progress-bar-element po-progress-bar-primary" style="transform: scaleX(0.5);"></div>
         <div class="po-progress-bar-element po-progress-bar-secondary"></div>
       </div>
 
@@ -90,7 +90,7 @@
       </label>
 
       <div class="po-progress-bar">
-        <div class="po-progress-bar-element po-progress-bar-primary" style="transform: scaleX(0.50);"></div>
+        <div class="po-progress-bar-element po-progress-bar-primary" style="transform: scaleX(0.5);"></div>
         <div class="po-progress-bar-element po-progress-bar-secondary"></div>
       </div>
 

--- a/src/css/components/po-slide/po-slide.html
+++ b/src/css/components/po-slide/po-slide.html
@@ -124,7 +124,7 @@
         </div>
         <div class="po-slide-control-next">
           <div class="po-slide-arrow-circle">
-            <div class=" po-slide-arrow po-slide-arrow-next"></div>
+            <div class="po-slide-arrow po-slide-arrow-next"></div>
           </div>
         </div>
       </div>
@@ -215,7 +215,7 @@
         </div>
         <div class="po-slide-control-next">
           <div class="po-slide-arrow-circle">
-            <div class=" po-slide-arrow po-slide-arrow-next"></div>
+            <div class="po-slide-arrow po-slide-arrow-next"></div>
           </div>
         </div>
       </div>
@@ -295,7 +295,7 @@
         </div>
         <div class="po-slide-control-next">
           <div class="po-slide-arrow-circle">
-            <div class=" po-slide-arrow po-slide-arrow-next"></div>
+            <div class="po-slide-arrow po-slide-arrow-next"></div>
           </div>
         </div>
       </div>
@@ -333,7 +333,7 @@
         </div>
         <div class="po-slide-control-next">
           <div class="po-slide-arrow-circle">
-            <div class=" po-slide-arrow po-slide-arrow-next"></div>
+            <div class="po-slide-arrow po-slide-arrow-next"></div>
           </div>
         </div>
       </div>
@@ -356,14 +356,14 @@
           <div
             p-slide-item
             class="po-slide-item po-slide-item-background-image"
-            style="background-image: url(http://lorempixel.com/1200/600/animals/)"
+            style="background-image: url(http://lorempixel.com/1200/600/animals/);"
           >
             <a class="po-slide-item-link" href="https://po-ui.io"></a>
           </div>
           <div
             p-slide-item
             class="po-slide-item po-slide-item-background-image"
-            style="background-image: url(http://lorempixel.com/1200/600/city/)"
+            style="background-image: url(http://lorempixel.com/1200/600/city/);"
           >
             <a class="po-slide-item-link" href="https://po-ui.io"></a>
           </div>
@@ -375,7 +375,7 @@
         </div>
         <div class="po-slide-control-next">
           <div class="po-slide-arrow-circle">
-            <div class=" po-slide-arrow po-slide-arrow-next"></div>
+            <div class="po-slide-arrow po-slide-arrow-next"></div>
           </div>
         </div>
       </div>

--- a/src/css/components/po-stepper/po-stepper.html
+++ b/src/css/components/po-stepper/po-stepper.html
@@ -14,13 +14,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">1</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -34,13 +34,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">2</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -54,13 +54,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">3</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -74,13 +74,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">4</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -94,13 +94,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">5</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -123,13 +123,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">1</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -143,13 +143,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">2</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -163,13 +163,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">3</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -183,13 +183,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
                     <span class="po-stepper-circle-content">4</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -203,13 +203,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle">
                     <span class="po-stepper-circle-content">5</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -232,13 +232,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
                     <span class="po-stepper-circle-content po-icon po-icon-ok"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -252,13 +252,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-error">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
                     <span class="po-stepper-circle-content po-icon po-icon-exclamation"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -272,13 +272,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
                     <span class="po-stepper-circle-content po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -292,13 +292,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
                     <span class="po-stepper-circle-content po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -312,13 +312,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 12px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 12px;"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon">
                     <span class="po-stepper-circle-content po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 12px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 12px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -340,7 +340,7 @@
           <div class="po-stepper-container">
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -360,7 +360,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -380,7 +380,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -400,7 +400,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -420,7 +420,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -449,7 +449,7 @@
           <div class="po-stepper-container">
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -469,7 +469,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -489,7 +489,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -509,7 +509,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle" tabindex="0">
@@ -529,7 +529,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle">
@@ -558,7 +558,7 @@
           <div class="po-stepper-container">
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
@@ -578,7 +578,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-error">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
@@ -598,7 +598,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
@@ -618,7 +618,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon" tabindex="0">
@@ -638,7 +638,7 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
-                <div class="po-stepper-step-container" style="width: 24px">
+                <div class="po-stepper-step-container" style="width: 24px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div class="po-stepper-circle po-stepper-circle-with-icon">
@@ -668,13 +668,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">1</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -688,13 +688,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">2</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -708,13 +708,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">3</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -728,13 +728,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">4</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -748,13 +748,13 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">5</span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -777,17 +777,17 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-ok"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -801,19 +801,19 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-error">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span
                       class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-exclamation"
                     ></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -827,17 +827,17 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -851,17 +851,17 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -875,17 +875,17 @@
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
                 <div class="po-stepper-step-container">
-                  <div class="po-stepper-step-bar-left" style="margin-right: 32px"></div>
+                  <div class="po-stepper-step-bar-left" style="margin-right: 32px;"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>
 
-                  <div class="po-stepper-step-bar-right" style="margin-left: 32px"></div>
+                  <div class="po-stepper-step-bar-right" style="margin-left: 32px;"></div>
                 </div>
 
                 <div class="po-stepper-step-label-position">
@@ -909,8 +909,8 @@
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-bar-top"></div>
 
-                <div class="po-stepper-step-container" style="width: 64px">
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">1</span>
                   </div>
 
@@ -927,10 +927,10 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-done">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">2</span>
                   </div>
 
@@ -947,10 +947,10 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">3</span>
                   </div>
 
@@ -967,10 +967,10 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">4</span>
                   </div>
 
@@ -987,10 +987,10 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
-                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px">
+                  <div class="po-stepper-circle" tabindex="0" style="height: 64px; width: 64px;">
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg">5</span>
                   </div>
 
@@ -1018,11 +1018,11 @@
               <div class="po-stepper-step po-stepper-step-done">
                 <div class="po-stepper-step-bar-top"></div>
 
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-ok"></span>
                   </div>
@@ -1040,13 +1040,13 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-error">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span
                       class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-exclamation"
@@ -1066,13 +1066,13 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-active">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>
@@ -1090,13 +1090,13 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-default">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>
@@ -1114,13 +1114,13 @@
 
             <div class="po-stepper-step-position">
               <div class="po-stepper-step po-stepper-step-disabled">
-                <div class="po-stepper-step-container" style="width: 64px">
+                <div class="po-stepper-step-container" style="width: 64px;">
                   <div class="po-stepper-step-bar-top"></div>
 
                   <div
                     class="po-stepper-circle po-stepper-circle-with-icon"
                     tabindex="0"
-                    style="height: 64px; width: 64px"
+                    style="height: 64px; width: 64px;"
                   >
                     <span class="po-stepper-circle-content po-stepper-circle-content-lg po-icon po-icon-info"></span>
                   </div>

--- a/src/css/components/po-table/po-table.html
+++ b/src/css/components/po-table/po-table.html
@@ -71,20 +71,20 @@
 
 <div class="container">
   <h4>Tipos de ordenação</h4>
-  <table style="border-spacing:10px;width:50%">
+  <table style="border-spacing: 10px; width: 50%;">
     <tr>
       <th>Ordenação ascendente</th>
       <th>Ordenação descendente</th>
       <th>Sem ordenação</th>
     </tr>
     <tr>
-      <td style="text-align:center">
+      <td style="text-align: center;">
         <span class="po-table-header-icon-ascending"></span>
       </td>
-      <td style="text-align:center">
+      <td style="text-align: center;">
         <span class="po-table-header-icon-descending"></span>
       </td>
-      <td style="text-align:center">
+      <td style="text-align: center;">
         <span class="po-table-header-icon-unselected"></span>
       </td>
     </tr>
@@ -2243,7 +2243,7 @@
       </div>
     </div>
 
-    <div class="po-modal" style="display:none;">
+    <div class="po-modal" style="display: none;">
       <div class="po-modal-overlay">
         <div class="po-modal-container po-p-2">
           <div class="po-modal-vertical-align">
@@ -2961,12 +2961,12 @@
                       <span class="po-table-subtitle-circle po-color-11">1</span>
                     </div>
                   </td>
-                  <td class="po-table-column  sample-po-table-column-width">
+                  <td class="po-table-column sample-po-table-column-width">
                     <div class="po-table-column-cell">
                       Argentina / Buenos Aires
                     </div>
                   </td>
-                  <td class="po-table-column  sample-po-table-column-width">
+                  <td class="po-table-column sample-po-table-column-width">
                     <div class="po-table-column-cell">
                       13/02/2018
                     </div>
@@ -3313,12 +3313,12 @@
                       <span class="po-table-subtitle-circle po-color-11">1</span>
                     </div>
                   </td>
-                  <td class="po-table-column  sample-po-table-column-width-large">
+                  <td class="po-table-column sample-po-table-column-width-large">
                     <div class="po-table-column-cell">
                       Argentina / Buenos Aires
                     </div>
                   </td>
-                  <td class="po-table-column  sample-po-table-column-width-large">
+                  <td class="po-table-column sample-po-table-column-width-large">
                     <div class="po-table-column-cell">
                       13/02/2018
                     </div>

--- a/src/css/components/po-tabs/po-tabs.html
+++ b/src/css/components/po-tabs/po-tabs.html
@@ -50,10 +50,10 @@
     </div>
 
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
     </div>
 
     <h4>Tabs simples (small):</h4>
@@ -82,10 +82,10 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
     </div>
 
     <h4>Tab selecionada:</h4>
@@ -115,9 +115,9 @@
     </div>
     <div class="po-tabs-content po-tab-content">
       <div>Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
     </div>
 
     <h4>Tab desabilitada:</h4>
@@ -146,10 +146,10 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
     </div>
 
     <h4>Tabs com dropdown "Mais" fechado, quando haver seis ou mais tabs:</h4>
@@ -186,12 +186,12 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
     </div>
 
     <h4>Tabs com dropdown "Mais" aberto, quando haver seis ou mais tabs:</h4>
@@ -259,18 +259,18 @@
       </div>
     </div>
     <div class="po-tab-content po-tabs-margin-bottom">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
-      <div style="display:none">Tab 7</div>
-      <div style="display:none">Tab 8</div>
-      <div style="display:none">Tab 9</div>
-      <div style="display:none">Tab 10</div>
-      <div style="display:none">Tab 11</div>
-      <div style="display:none">Tab 12</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
+      <div style="display: none;">Tab 7</div>
+      <div style="display: none;">Tab 8</div>
+      <div style="display: none;">Tab 9</div>
+      <div style="display: none;">Tab 10</div>
+      <div style="display: none;">Tab 11</div>
+      <div style="display: none;">Tab 12</div>
     </div>
 
     <h4>Tabs com dropdown "Mais" aberto, quando haver seis ou mais tabs (small):</h4>
@@ -338,18 +338,18 @@
       </div>
     </div>
     <div class="po-tab-content po-tabs-margin-bottom">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
-      <div style="display:none">Tab 7</div>
-      <div style="display:none">Tab 8</div>
-      <div style="display:none">Tab 9</div>
-      <div style="display:none">Tab 10</div>
-      <div style="display:none">Tab 11</div>
-      <div style="display:none">Tab 12</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
+      <div style="display: none;">Tab 7</div>
+      <div style="display: none;">Tab 8</div>
+      <div style="display: none;">Tab 9</div>
+      <div style="display: none;">Tab 10</div>
+      <div style="display: none;">Tab 11</div>
+      <div style="display: none;">Tab 12</div>
     </div>
 
     <h4>Botão "Mais" com dropdown aberto e tab selecionada</h4>
@@ -402,12 +402,12 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
       <div>Tab 5</div>
-      <div style="display:none">Tab 6</div>
+      <div style="display: none;">Tab 6</div>
     </div>
 
     <h4>Botão "Mais" com dropdown aberto e tab desabilitada</h4>
@@ -460,12 +460,12 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
     </div>
 
     <h3>Comportamento MOBILE</h3>
@@ -512,13 +512,13 @@
     </div>
 
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
-      <div style="display:none">Tab 7</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
+      <div style="display: none;">Tab 7</div>
     </div>
 
     <h4>Tabs simples com scroll horizontal (small):</h4>
@@ -562,13 +562,13 @@
       </div>
     </div>
     <div class="po-tabs-content po-tab-content">
-      <div style="display:none">Tab 1</div>
-      <div style="display:none">Tab 2</div>
-      <div style="display:none">Tab 3</div>
-      <div style="display:none">Tab 4</div>
-      <div style="display:none">Tab 5</div>
-      <div style="display:none">Tab 6</div>
-      <div style="display:none">Tab 7</div>
+      <div style="display: none;">Tab 1</div>
+      <div style="display: none;">Tab 2</div>
+      <div style="display: none;">Tab 3</div>
+      <div style="display: none;">Tab 4</div>
+      <div style="display: none;">Tab 5</div>
+      <div style="display: none;">Tab 6</div>
+      <div style="display: none;">Tab 7</div>
     </div>
   </section>
 </article>

--- a/src/css/components/po-toolbar/po-toolbar.html
+++ b/src/css/components/po-toolbar/po-toolbar.html
@@ -61,7 +61,7 @@
           <div class="po-toolbar-notification po-clickable">
             <span class="po-icon po-icon-notification po-toolbar-icon"></span>
 
-            <div class="po-popup" style="margin-top: 8px; margin-left: -201px">
+            <div class="po-popup" style="margin-top: 8px; margin-left: -201px;">
               <div class="po-popup-arrow po-arrow-top-right"></div>
               <div class="po-popup-item-default po-clickable">
                 <span class="po-icon po-icon-message po-popup-icon-item"></span>
@@ -95,7 +95,7 @@
         <div class="po-toolbar-group-icon">
           <div class="po-toolbar-actions po-clickable">
             <span class="po-icon po-icon-more po-toolbar-icon"></span>
-            <div class="po-popup" style="margin-top: 8px; margin-left: -105px">
+            <div class="po-popup" style="margin-top: 8px; margin-left: -105px;">
               <div class="po-popup-arrow po-arrow-top-right"></div>
               <div class="po-popup-item-default po-clickable">
                 Abrir caixa
@@ -135,7 +135,7 @@
               <img alt="" class="po-avatar-image" />
             </div>
 
-            <div class="po-popup" style="margin-top: 8px; margin-left: -222px">
+            <div class="po-popup" style="margin-top: 8px; margin-left: -222px;">
               <div class="po-popup-arrow po-arrow-top-right"></div>
 
               <div class="po-toolbar-profile-item-header">

--- a/src/css/components/po-tree-view/po-tree-view.html
+++ b/src/css/components/po-tree-view/po-tree-view.html
@@ -43,7 +43,7 @@
         <ul class="po-tree-view">
           <li class="po-tree-view-item">
             <div class="po-tree-view-item-header">
-              <div class="po-tree-view-item-header-checkbox  po-tree-view-item-header-padding">
+              <div class="po-tree-view-item-header-checkbox po-tree-view-item-header-padding">
                 <div class="po-checkbox">
                   <input class="po-input po-checkbox-input" type="checkbox" />
                   <label tabindex="0" class="po-checkbox-label po-clickable">
@@ -80,7 +80,7 @@
         <ul class="po-tree-view">
           <li class="po-tree-view-item">
             <div class="po-tree-view-item-header">
-              <div class="po-tree-view-item-header-checkbox  po-tree-view-item-header-padding">
+              <div class="po-tree-view-item-header-checkbox po-tree-view-item-header-padding">
                 <div class="po-checkbox">
                   <input class="po-input po-checkbox-input po-checkbox-input-checked" checked type="checkbox" />
                   <label tabindex="0" class="po-checkbox-label po-clickable">

--- a/src/css/components/po-upload/po-upload.html
+++ b/src/css/components/po-upload/po-upload.html
@@ -16,7 +16,7 @@
 </style>
 
 <script>
-  (function() {
+  (function () {
     let timeout;
 
     init();
@@ -44,7 +44,7 @@
 
     document.getElementById('uploadPage').addEventListener(
       'dragover',
-      function(event) {
+      function (event) {
         event.preventDefault();
 
         clearTimeout(timeout);
@@ -58,7 +58,7 @@
 
     document.getElementById('uploadPage').addEventListener(
       'dragleave',
-      function(event) {
+      function (event) {
         event.preventDefault();
 
         timeout = setTimeout(() => {
@@ -530,7 +530,7 @@
 
           <!-- DRAG DROP AREA -->
           <div>
-            <div class="po-upload-drag-drop-area" style="height: 320px">
+            <div class="po-upload-drag-drop-area" style="height: 320px;">
               <div class="po-upload-drag-drop-area-container">
                 <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
@@ -585,7 +585,7 @@
 
           <!-- DRAG DROP AREA -->
           <div>
-            <div class="po-upload-drag-drop-area" style="height: 320px">
+            <div class="po-upload-drag-drop-area" style="height: 320px;">
               <div class="po-upload-drag-drop-area-container">
                 <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
@@ -640,7 +640,7 @@
 
           <!-- DRAG DROP AREA -->
           <div>
-            <div class="po-upload-drag-drop-area" style="height: 320px">
+            <div class="po-upload-drag-drop-area" style="height: 320px;">
               <div class="po-upload-drag-drop-area-container">
                 <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
@@ -725,7 +725,7 @@
 
           <!-- DRAG DROP AREA -->
           <div id="dragDropArea">
-            <div class="po-upload-drag-drop-area" style="height: 320px">
+            <div class="po-upload-drag-drop-area" style="height: 320px;">
               <div class="po-upload-drag-drop-area-container">
                 <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
@@ -749,7 +749,7 @@
 
           <!-- DRAG DROP AREA -->
           <div>
-            <div class="po-upload-drag-drop-area po-upload-drag-drop-area-disabled" style="height: 320px">
+            <div class="po-upload-drag-drop-area po-upload-drag-drop-area-disabled" style="height: 320px;">
               <div class="po-upload-drag-drop-area-container">
                 <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 
@@ -776,7 +776,7 @@
 
             <!-- DRAG DROP AREA -->
             <div>
-              <div class="po-upload-drag-drop-area" style="height: 320px">
+              <div class="po-upload-drag-drop-area" style="height: 320px;">
                 <div class="po-upload-drag-drop-area-container">
                   <span class="po-upload-drag-drop-area-icon po-icon po-icon-upload-cloud"></span>
 

--- a/src/css/components/po-widget/po-widget.html
+++ b/src/css/components/po-widget/po-widget.html
@@ -104,7 +104,7 @@
       </div>
 
       <div class="po-md-4 sample-widget">
-        <div class="po-widget" style="height: 200px">
+        <div class="po-widget" style="height: 200px;">
           <div class="po-widget-header">
             Título
             <div class="po-pull-right">
@@ -112,7 +112,7 @@
               <span class="po-clickable po-icon po-icon-help"></span>
             </div>
           </div>
-          <div class="po-container po-container-no-border" style="height: 112px">
+          <div class="po-container po-container-no-border" style="height: 112px;">
             <div class="po-widget-body">
               <h4>
                 Widget com título, ações primária, secundária, configuração, ajuda e bastante conteúdo. Lorem ipsum
@@ -239,7 +239,7 @@
       </div>
 
       <div class="po-md-4 sample-widget">
-        <div class="po-widget po-clickable" style="height: 40px">
+        <div class="po-widget po-clickable" style="height: 40px;">
           <div class="po-container po-container-no-border">
             <div class="po-widget-body">
               <h4>Widget com altura fixa.</h4>
@@ -261,7 +261,7 @@
 
     <div class="po-row">
       <div class="po-md-4 sample-widget">
-        <div class="po-widget po-widget-disabled po-clickable" style="height: 200px">
+        <div class="po-widget po-widget-disabled po-clickable" style="height: 200px;">
           <div class="po-widget-header">
             <span class="po-widget-title-action">
               Título
@@ -271,7 +271,7 @@
               <span class="po-clickable po-icon po-icon-help"></span>
             </div>
           </div>
-          <div class="po-container po-container-no-border" style="height: 112px">
+          <div class="po-container po-container-no-border" style="height: 112px;">
             <div class="po-widget-body">
               <h4>
                 Widget desabilitado com título, ações primária, secundária e principal, configuração, ajuda e bastante
@@ -295,7 +295,7 @@
       </div>
 
       <div class="po-md-4 sample-widget">
-        <div class="po-widget-primary po-widget-disabled po-clickable" style="height: 200px">
+        <div class="po-widget-primary po-widget-disabled po-clickable" style="height: 200px;">
           <div class="po-widget-header">
             Título
             <div class="po-pull-right">
@@ -303,7 +303,7 @@
               <span class="po-clickable po-icon po-icon-help"></span>
             </div>
           </div>
-          <div class="po-container po-container-no-border" style="height: 112px">
+          <div class="po-container po-container-no-border" style="height: 112px;">
             <div class="po-widget-body">
               <h4>
                 Widget primário desabilitado com título, ações primária, secundária e principal, configuração, ajuda e

--- a/src/css/sample-app/po-menu.html
+++ b/src/css/sample-app/po-menu.html
@@ -7,7 +7,7 @@
 
 <link rel="stylesheet" href="../../../dist/po-theme/css/po-theme-default.min.css" />
 <div class="po-wrapper">
-  <div class="po-menu-overlay" style="display:none"></div>
+  <div class="po-menu-overlay" style="display: none;"></div>
   <div class="po-menu-mobile">
     <span class="po-icon po-icon-menu po-clickable" onclick="showMenuResponsive()"></span>
   </div>

--- a/src/css/services/po-notification/po-toaster/po-toaster.html
+++ b/src/css/services/po-notification/po-toaster/po-toaster.html
@@ -10,7 +10,7 @@
     <div>
       <h4>Sem ação e sem ícone</h4>
       <div class="po-toaster po-toaster-success">
-        <div class="po-toaster-message  po-toaster-success">
+        <div class="po-toaster-message po-toaster-success">
           Mensagem do po-toaster - Sucesso
         </div>
       </div>
@@ -41,7 +41,7 @@
         <div class="po-toaster-message">
           <span class="po-icon po-icon-info"></span> Mensagem do po-toaster - Informação
         </div>
-        <div class="po-toaster-action ">
+        <div class="po-toaster-action">
           Fechar
         </div>
       </div>
@@ -57,7 +57,7 @@
 
       <div class="po-toaster po-toaster-error">
         <div class="po-toaster-message"><span class="po-icon po-icon-close"></span> Mensagem do po-toaster - Falha</div>
-        <div class="po-toaster-action ">
+        <div class="po-toaster-action">
           Fechar
         </div>
       </div>


### PR DESCRIPTION
**Po Style**

- Atualização do pacote `autoprefixer`
- Atualização do pacote `prettier`:
    - Também foi atualizado os arquivos conforme as regras da nova atualização.
    - Desabilitação das regras [arrowParens](https://prettier.io/docs/en/options.html#arrow-function-parentheses) e [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas)

Para testar:
- Limpar a pasta node_module e executar comando `npm i`
- executar `npm run format:all` e verificar se não falta nenhuma regra nova. 
- executar o portal do `po-style` para ver se continua executando normalmente.