### PR TITLE
fix(field-container): corrige visualização no IE

### DIFF
--- a/src/css/components/po-field/po-field-container/po-field-container.css
+++ b/src/css/components/po-field/po-field-container/po-field-container.css
@@ -12,10 +12,6 @@
   }
 }
 
-.po-field-container {
-  position: relative;
-}
-
 /* Classe que possibilita colocar o botão de clean na mesma linha, */
 .po-field-container-content {
   padding: 8px 0;


### PR DESCRIPTION
A definição de `position relative` para a classe `po-field-container` gerava efeito colateral de overflow no IE quando utilizado um input de seleção dentro do `po-container`.

**Simulação**

A classe `po-field-container` é amplamente utilizada pelos componentes `po-field`, então é recomendada a revisão dos componentes abaixo no portal.
- checkbox-group
- combo
- datepicker
- datepicker-range
- decimal
- input
- login
- lookup
- multiselect
- number
- password
- radio-group
- rich-text
- select
- switch
- textarea
- upload

Além do mencionado acima, atentar ao escopo da tarefa que é o teste em IE para um elemento `po-container` contendo um `po-select`. 

Fixes DTHFUI-3098