### PR TITLE
feat(table): implementa nova posição do icone sort

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -358,7 +358,6 @@
 .po-table-header-subtitle {
   max-width: 80px;
   min-width: 80px;
-  text-align: center;
   width: 80px;
 }
 
@@ -405,29 +404,36 @@
   padding: 0 4px;
 }
 
-.po-table-header-block {
-  display: block;
+.po-table-header-flex {
+  display: flex;
+  align-items: center;
 }
 
-.po-table-header-icon-ascending::after {
+.po-table-header-flex-right {
+  justify-content: flex-end;
+}
+
+.po-table-header-flex-center {
+  justify-content: center;
+}
+
+.po-table-header-icon-ascending::before,
+.po-table-header-icon-descending::before,
+.po-table-header-icon-unselected::before {
+  vertical-align: sub;
+  white-space: nowrap;
+}
+
+.po-table-header-icon-ascending::before {
   content: url('../images/order-ascending.svg');
-  float: right;
-  vertical-align: sub;
-  white-space: nowrap;
 }
 
-.po-table-header-icon-descending::after {
+.po-table-header-icon-descending::before {
   content: url('../images/order-descending.svg');
-  float: right;
-  vertical-align: sub;
-  white-space: nowrap;
 }
 
-.po-table-header-icon-unselected::after {
+.po-table-header-icon-unselected::before {
   content: url('../images/order-unselected.svg');
-  float: right;
-  vertical-align: sub;
-  white-space: nowrap;
 }
 
 .po-table .po-table-column-selectable {

--- a/src/css/components/po-table/po-table.html
+++ b/src/css/components/po-table/po-table.html
@@ -98,22 +98,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -346,22 +358,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
             </tr>
           </thead>
@@ -583,22 +607,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager po-table-header-column-manager-border">
                 <div>
@@ -727,22 +763,34 @@
             <tr class="po-table-header">
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager po-table-header-column-manager-border">
                 <div>
@@ -957,22 +1005,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager po-table-header-column-manager-border">
                 <div>
@@ -1100,22 +1160,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -1172,22 +1244,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -1330,22 +1414,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -1508,25 +1604,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Ícones</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Ícones</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -1667,25 +1777,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Ícones</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Ícones</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -1869,25 +1993,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-table-header-subtitle">
-                <span class="po-table-header-ellipsis po-table-header-block">Status</span>
+                <div class="po-table-header-flex po-table-header-flex-center">
+                  <span class="po-table-header-ellipsis">Status</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -2046,25 +2184,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-table-header-subtitle">
-                <span class="po-table-header-ellipsis po-table-header-block">Status</span>
+                <div class="po-table-header-flex po-table-header-flex-center">
+                  <span class="po-table-header-ellipsis">Status</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -2223,10 +2375,14 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-table-header-subtitle">
-                <span class="po-table-header-ellipsis po-table-header-block">Cor</span>
+                <div class="po-table-header-flex po-table-header-flex-center">
+                  <span class="po-table-header-ellipsis">Cor</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Descrição</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Descrição</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -2573,25 +2729,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Status</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Status</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -2783,22 +2953,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -2935,25 +3117,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-table-header-subtitle">
-                <span class="po-table-header-ellipsis po-table-header-block">Status</span>
+                <div class="po-table-header-flex po-table-header-flex-center">
+                  <span class="po-table-header-ellipsis">Status</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -3131,45 +3327,49 @@
                   </th>
                   <th class="po-table-header-master-detail"></th>
                   <th class="po-table-header-ellipsis po-table-header-subtitle">
-                    <div class="po-table-header-fixed-inner po-table-header-subtitle">
+                    <div class="po-table-header-flex po-table-header-fixed-inner po-table-header-flex-center">
+                      <span class="po-table-header-ellipsis">Status</span>
                       <span class="po-table-header-icon-ascending"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Status</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width">
+                      <span class="po-table-header-ellipsis">Destino</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width">
+                      <span class="po-table-header-ellipsis">Data</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                    </div>
-                  </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
-                      <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
+                    <div
+                      class="po-table-header-flex po-table-header-flex-right po-table-header-fixed-inner sample-po-table-column-width"
+                    >
+                      <span class="po-table-header-ellipsis">Poltrona</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
                     </div>
                   </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
+                  <th class="po-table-header-ellipsis sample-po-table-column-width">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width">
+                      <span class="po-table-header-ellipsis">Classe</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
                     </div>
                   </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width">
+                  <th class="po-table-header-ellipsis sample-po-table-column-width">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width">
+                      <span class="po-table-header-ellipsis">Código Passagem</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                    </div>
+                  </th>
+                  <th class="po-table-header-ellipsis sample-po-table-column-width">
+                    <div
+                      class="po-table-header-flex po-table-header-flex-right po-table-header-fixed-inner sample-po-table-column-width"
+                    >
+                      <span class="po-table-header-ellipsis">Valor</span>
+                      <span class="po-table-header-icon-unselected"></span>
                     </div>
                   </th>
                   <th class="po-table-header-column-manager">
@@ -3489,45 +3689,51 @@
                 <tr>
                   <th class="po-table-header-master-detail"></th>
                   <th class="po-table-header-ellipsis po-table-header-subtitle">
-                    <div class="po-table-header-fixed-inner po-table-header-subtitle">
+                    <div class="po-table-header-flex po-table-header-fixed-inner po-table-header-flex-center">
+                      <span class="po-table-header-ellipsis">Status</span>
                       <span class="po-table-header-icon-ascending"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Status</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width-large">
+                      <span class="po-table-header-ellipsis">Destino</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width-large">
+                      <span class="po-table-header-ellipsis">Data</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                    </div>
-                  </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
-                      <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
                     </div>
                   </th>
                   <th class="po-table-header-ellipsis sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
+                    <div
+                      class="po-table-header-flex po-table-header-flex-right po-table-header-fixed-inner sample-po-table-column-width-large"
+                    >
+                      <span class="po-table-header-ellipsis">Poltrona</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
                     </div>
                   </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
+                  <th class="po-table-header-ellipsis sample-po-table-column-width-large">
+                    <div class="po-table-header-flex po-table-header-fixed-inner sample-po-table-column-width-large">
+                      <span class="po-table-header-ellipsis">Classe</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
                     </div>
                   </th>
-                  <th class="po-table-header-ellipsis po-table-column-right sample-po-table-column-width-large">
-                    <div class="po-table-header-fixed-inner sample-po-table-column-width-large">
+                  <th class="po-table-header-ellipsis sample-po-table-column-width-large">
+                    <div
+                      class="po-table-header-flex po-table-header-flex-right po-table-header-fixed-inner sample-po-table-column-width-large"
+                    >
+                      <span class="po-table-header-ellipsis">Código Passagem</span>
                       <span class="po-table-header-icon-unselected"></span>
-                      <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                    </div>
+                  </th>
+                  <th class="po-table-header-ellipsis sample-po-table-column-width-large">
+                    <div
+                      class="po-table-header-flex po-table-header-flex-right po-table-header-fixed-inner sample-po-table-column-width-large"
+                    >
+                      <span class="po-table-header-ellipsis">Valor</span>
+                      <span class="po-table-header-icon-unselected"></span>
                     </div>
                   </th>
                   <th class="po-table-header-column-manager">
@@ -3796,22 +4002,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-single-action">
                 <div>
@@ -3990,22 +4208,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-single-action">
                 <div>
@@ -4194,22 +4424,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -4361,22 +4603,34 @@
             <tr class="po-table-header">
               <th class="po-table-column-selectable"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -4521,22 +4775,34 @@
             <tr class="po-table-header">
               <th class="po-table-column-selectable"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-actions"></th>
             </tr>
@@ -4680,22 +4946,34 @@
                 <label class="po-table-checkbox-label" for="checkbox1"></label>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -4842,22 +5120,34 @@
             <tr class="po-table-header">
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -5075,22 +5365,34 @@
             <tr class="po-table-header">
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -5304,22 +5606,34 @@
             <tr class="po-table-header">
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -5549,22 +5863,34 @@
               </th>
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -5824,22 +6150,34 @@
               </th>
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -6077,22 +6415,34 @@
             <tr class="po-table-header">
               <th class="po-table-header-master-detail"></th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -6300,22 +6650,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -6522,28 +6884,40 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-icon-ascending"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                  <span class="po-table-header-icon-ascending"></span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-icon-unselected"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-icon-unselected"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                  <span class="po-table-header-icon-unselected"></span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-icon-unselected"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                  <span class="po-table-header-icon-unselected"></span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-icon-unselected"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                  <span class="po-table-header-icon-unselected"></span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-icon-unselected"></span>
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                  <span class="po-table-header-icon-unselected"></span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                  <span class="po-table-header-icon-unselected"></span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -6677,25 +7051,39 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-ellipsis po-table-header-block">Descrição</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Descrição</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis po-clickable">
-                <span class="po-table-header-ellipsis po-table-header-block">Classe</span>
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-header-number po-clickable po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis po-clickable">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -6863,22 +7251,34 @@
             <thead>
               <tr class="po-table-header">
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Destino</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Data</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  Classe
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Poltrona</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Classe</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Código Passagem</span>
+                  </div>
+                </th>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Valor</span>
+                  </div>
                 </th>
                 <th class="po-table-header-column-manager">
                   <div>
@@ -7131,22 +7531,34 @@
             <thead>
               <tr class="po-table-header">
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Destino</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Data</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  Classe
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Poltrona</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Classe</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Código Passagem</span>
+                  </div>
+                </th>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Valor</span>
+                  </div>
                 </th>
                 <th class="po-table-header-column-manager">
                   <div>
@@ -7226,22 +7638,34 @@
             <thead>
               <tr class="po-table-header">
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Destino</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Data</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  Classe
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Poltrona</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Classe</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Código Passagem</span>
+                  </div>
+                </th>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Valor</span>
+                  </div>
                 </th>
               </tr>
             </thead>
@@ -7288,22 +7712,34 @@
             <thead>
               <tr class="po-table-header">
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Destino</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Data</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  Classe
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Poltrona</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Classe</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Código Passagem</span>
+                  </div>
+                </th>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Valor</span>
+                  </div>
                 </th>
                 <th class="po-table-header-column-manager">
                   <div>
@@ -7462,22 +7898,34 @@
             <thead>
               <tr class="po-table-header">
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Destino</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-                </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Data</span>
+                  </div>
                 </th>
                 <th class="po-table-header-ellipsis">
-                  Classe
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Poltrona</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex">
+                    <span class="po-table-header-ellipsis">Classe</span>
+                  </div>
                 </th>
-                <th class="po-table-header-ellipsis po-table-column-right">
-                  <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Código Passagem</span>
+                  </div>
+                </th>
+                <th class="po-table-header-ellipsis">
+                  <div class="po-table-header-flex po-table-header-flex-right">
+                    <span class="po-table-header-ellipsis">Valor</span>
+                  </div>
                 </th>
                 <th class="po-table-header-column-manager">
                   <div>
@@ -7625,22 +8073,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -7776,22 +8236,34 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
-              </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                Classe
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Código Passagem</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Classe</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Valor</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Código Passagem</span>
+                </div>
+              </th>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Valor</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>
@@ -8016,13 +8488,19 @@
           <thead>
             <tr class="po-table-header">
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Destino</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Destino</span>
+                </div>
               </th>
               <th class="po-table-header-ellipsis">
-                <span class="po-table-header-ellipsis po-table-header-block">Data</span>
+                <div class="po-table-header-flex">
+                  <span class="po-table-header-ellipsis">Data</span>
+                </div>
               </th>
-              <th class="po-table-header-ellipsis po-table-column-right">
-                <span class="po-table-header-ellipsis po-table-header-block">Poltrona</span>
+              <th class="po-table-header-ellipsis">
+                <div class="po-table-header-flex po-table-header-flex-right">
+                  <span class="po-table-header-ellipsis">Poltrona</span>
+                </div>
               </th>
               <th class="po-table-header-column-manager">
                 <div>


### PR DESCRIPTION
Alterado a posição padrão do íconde de ordenação de coluna do PO-TABLE,
passando da direita para a esquerda junto ao texto.

FIX DTHFUI-3798