### PR TITLE
feat(combo): adiciona a propriedade p-clean

### DIFF
--- a/src/css/components/po-field/po-combo/po-combo.html
+++ b/src/css/components/po-field/po-combo/po-combo.html
@@ -34,8 +34,9 @@
               <span class="po-icon po-field-icon po-icon-gift"></span>
             </div>
 
-            <input type="text" class="po-input po-input-icon-right po-input-icon-left" value="Joinville" />
+            <input type="text" class="po-input po-input-double-icon-right po-input-icon-left" value="Joinville" />
             <div class="po-field-icon-container-right">
+              <span class="po-icon po-field-icon po-icon-close"></span>
               <span class="po-icon po-field-icon po-icon-arrow-down"></span>
             </div>
           </div>

--- a/src/css/components/po-field/po-input/po-input.css
+++ b/src/css/components/po-field/po-input/po-input.css
@@ -35,7 +35,7 @@
 }
 
 .po-input-double-icon-right {
-  padding-right: 68px;
+  padding-right: 68px !important;
 }
 
 /* Desabilita o clean field e o reveal do IE 10+ */
@@ -97,6 +97,6 @@ po-url.ng-invalid.ng-dirty .po-input {
   }
 
   .po-input-double-icon-right {
-    padding-right: 52px;
+    padding-right: 52px !important;
   }
 }


### PR DESCRIPTION
Adiciona a propriedade p-clean no po-combo, permitindo limpar
o combo ao clicar no X localizado ao lado da seta de opções.

Fixes DTHFUI-2314, #152