### PR TITLE
fix(table): O loading esta ocupando todo o espaço no chrome

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -99,7 +99,6 @@
   background-color: var(--color-table-background-color-overlay-content);
   border-radius: 3px;
   box-shadow: 0 1px 4px 0 var(--color-table-box-shadow-overlay-content);
-  display: table;
   height: 90%;
   left: 50%;
   max-height: 104px;


### PR DESCRIPTION
Foi alterado uma atributo ao qual estava causando o bug que deixava o loading ocupado em todo espaço no chrome .

Fixes #667, MD8-38