### PR TITLE
feat(chart): define overflow:visible para svg

### DIFF
--- a/src/css/components/po-chart/po-chart.css
+++ b/src/css/components/po-chart/po-chart.css
@@ -37,7 +37,7 @@
 .po-chart-svg-element {
   display: block;
   margin: 0 auto;
-  overflow: hidden;
+  overflow: visible;
 }
 
 po-chart-legend {


### PR DESCRIPTION
Necessário `overflow:visible` para correta exibição dos elementos svgs desenhados nas extremidades do viewBox

Fixes DTHFUI-2805