### PR TITLE
fix(select): padroniza a altura do campo

### DIFF
--- a/src/css/components/po-field/po-select/po-select.css
+++ b/src/css/components/po-field/po-select/po-select.css
@@ -59,7 +59,7 @@
   box-sizing: content-box;
   color: var(--color-select-color-primary);
   cursor: pointer;
-  height: 24px;
+  height: 22px;
   overflow: hidden;
   padding: 10px 44px 10px 16px;
   position: relative;
@@ -141,7 +141,7 @@
 @media screen and (max-width: 1366px) {
   .po-select-button {
     @apply --font-select-text-smaller;
-    height: 16px;
+    height: 14px;
     line-height: 16px;
     padding: 8px 32px 8px 8px;
   }


### PR DESCRIPTION
A altura do campo estava 46px em +1366px e 34px em -1366px
fazendo que fique diferente dos demais.

A altura correta é 44px e 32px

Fixes DTHFUI-4636