### PR TITLE
feat(chart): centraliza labels do eixo y

### DIFF
--- a/src/css/components/po-chart/po-chart.css
+++ b/src/css/components/po-chart/po-chart.css
@@ -117,14 +117,6 @@ po-chart-legend {
   text-anchor: end;
 }
 
-.po-chart-axis-y-label:first-child {
-  text-anchor: start;
-}
-
-.po-chart-axis-y-label:last-child {
-  text-anchor: end;
-}
-
 .po-chart-axis-y-label,
 .po-chart-axis-y-label.po-chart-centered-label {
   text-anchor: middle;


### PR DESCRIPTION
Para os gráficos do tipo linha houve uma alteração de posicionamento em relação às categorias. Feito isso, foi necessário manter apenas as propriedades que centralizam o texto em relação à linha do eixo.

Fixes DTHFUI-2805