### PR TITLE
feat(popup): adiciona possibilidade de informar outras fontes de ícones

### DIFF
--- a/src/css/components/po-popup/po-popup.css
+++ b/src/css/components/po-popup/po-popup.css
@@ -71,6 +71,11 @@
   color: var(--color-popup-color-default);
 }
 
+.po-popup-icon-item.po-icon > :first-child:not(.po-fonts-icon):not(.po-icon) {
+  line-height: 1rem;
+  vertical-align: text-top;
+}
+
 .po-popup-item-disabled {
   color: var(--color-popup-color-disabled);
   cursor: default !important;


### PR DESCRIPTION
A pripriodade icon, permite informar outras fontes de ícones, até mesmo utilizando componentes via TemplateRef, mantendo a funcionalidade anterior.

Fixes DTHFUI-4906