### PR TITLE
feat(table): aumenta o tamanho do ícone de ações

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -253,6 +253,10 @@
   width: 40px;
 }
 
+.po-table-column-actions .po-icon.po-icon-more {
+  font-size: 24px;
+}
+
 .po-table-column-icons {
   @apply --font-table-icons;
   border-bottom: 1px solid var(--color-table-border-rows);
@@ -266,6 +270,10 @@
 
 .po-table-column-icons .po-icon {
   margin-right: 14px;
+}
+
+.po-table-column-icons .po-icon.po-icon-more {
+  font-size: 24px;
 }
 
 .po-table-footer {
@@ -283,10 +291,15 @@
 }
 
 .po-container .po-table-group-row:last-child .po-table-column,
-.po-container .po-table-group-row:last-child .po-table-column-detail,
 .po-container .po-table-group-row:last-child .po-table-column-icons,
-.po-container .po-table-group-row:last-child .po-table-column-actions {
+.po-container .po-table-group-row:last-child .po-table-column-actions,
+.po-container .po-table-group-row:last-child .po-table-column-detail-toggle {
   border-bottom: none;
+}
+
+.po-container .po-table-group-row:last-child .po-table-row + tr:not(.po-table-row) .po-table-column-detail {
+  border-bottom: none;
+  border-top: 1px solid var(--color-table-border-rows);
 }
 
 .po-table-footer-show-subtitle {
@@ -539,8 +552,10 @@
   background-color: var(--color-table-background-color-row-strip);
 }
 
+.po-table-master-detail .po-table-detail-row:last-child .po-table-column.po-table-column-selectable,
 .po-table-master-detail .po-table-detail-row:last-child .po-table-column-master-detail,
-.po-table-master-detail .po-table-detail-row:last-child .po-table-column-master-detail-space {
+.po-table-master-detail .po-table-detail-row:last-child .po-table-column-master-detail-space,
+.po-table-master-detail .po-table-detail-row:last-child .po-table-column-master-detail-space-checkbox {
   border-bottom: none;
 }
 
@@ -559,6 +574,7 @@
 
 .po-table-column-detail-toggle {
   text-align: center;
+  border-bottom: 1px solid var(--color-table-border-rows);
 }
 
 .po-table-header-master-detail,
@@ -566,7 +582,6 @@
   max-width: 35px;
   min-width: 35px;
   width: 35px;
-  border-bottom: 1px solid var(--color-table-border-rows);
 }
 
 .po-table-column-master-detail {
@@ -677,10 +692,13 @@
     padding-top: var(--table-row-height-sm);
   }
 
-  .po-table-column-icons,
+  .po-table-column-icons {
+    @apply --font-table-icons-sm;
+  }
+
   .po-table-column-detail-toggle .po-icon-arrow-down,
   .po-table-column-detail-toggle .po-icon-arrow-up {
-    @apply --font-table-icons-sm;
+    line-height: 24px;
   }
 
   .po-table-column-icons .po-icon {


### PR DESCRIPTION
**PO-TABLE**

**DTHFUI-4948**
_____________________________________________________________________________

**Qual o comportamento atual?**
O ícone de ações do componente `po-table` estava pequeno.

**Qual o novo comportamento?**
O ícone de ações do componente `po-table` teve um ajuste no tamanho.
Estava com 16px e foi alterado para 24px.


**Obs**
O ícone de mais detalhes também teve o tamanho alterado para 24px;
Em telas com resolução menor ou igual a 1366px ele tinha o tamanho de 16px e em telas com resolução maior que 1366px ele tinha o tamanho de 24px.

Também foi realizado ajuste nas bordas, corrigindo locais que precisavam ou não exibi-las.

**Simulação**
Bash -> `npm run build:portal && ng serve portal`
Powershell - > `npm run build:portal; ng serve portal`