### PR TITLE
fix(datepicker): corrige calendário ao abrir nas extremidades

### DIFF
--- a/src/css/components/po-calendar/po-calendar.css
+++ b/src/css/components/po-calendar/po-calendar.css
@@ -46,7 +46,7 @@
   height: var(--po-calendar-height);
   overflow: hidden;
   user-select: none;
-  display: inline-block;
+  display: inline-flex;
 }
 
 .po-calendar-range po-calendar-wrapper + po-calendar-wrapper .po-calendar-wrapper {
@@ -267,4 +267,10 @@
 .po-calendar-box-foreground-today-disabled {
   border-radius: 3px;
   padding: 2px;
+}
+
+@media screen and (max-width: 599.33px) {
+  .po-calendar-range {
+    width: var(--po-calendar-width);
+  }
 }


### PR DESCRIPTION
**DATEPICKER-RANGE**

**DTHFUI-5417**
_____________________________________________________________________________

**PR Checklist [Revisor]**

- [x] [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
- [x] [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
- [x] Testes unitários (Cobre a situação implementada e coverage está mantido)
- [x] [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
- [x] [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
- [x] Rodado em navegadores suportados (Chrome, FireFox, Edge)

**Qual o comportamento atual?**
Ao abrir calendário nas extremidades o mesmo é cortado na tela impossibilitando a escolha de datas

**Qual o novo comportamento?**
Ao abrir calendário nas extremidades o mesmo passa a exibir corretamente a escolha de datas

**Simulação**

`component.html`
```
<po-page-default p-title="PO UI">
    <p>Reproduza aqui sua issue.</p>
  
    <po-datepicker class="po-md-3"></po-datepicker>
    <po-datepicker class="po-md-3"></po-datepicker>
    <po-datepicker class="po-md-3"></po-datepicker>
    <po-datepicker-range class="po-md-3"></po-datepicker-range>
    
  </po-page-default>

```
`component.ts`
```
import { BrowserModule } from '@angular/platform-browser';
import { FormsModule } from '@angular/forms';
import { NgModule } from '@angular/core';
import { RouterModule } from '@angular/router';

import { AppComponent } from './app.component';
import { PoModule } from '../../../ui/src/lib';

@NgModule({
  declarations: [AppComponent],
  imports: [BrowserModule, FormsModule, RouterModule.forRoot([], { relativeLinkResolution: 'legacy' }), PoModule],
  bootstrap: [AppComponent]
})
export class AppModule {}

```
