### PR TITLE
fix(style): corrige cursor pointer e warnings

### DIFF
--- a/src/css/components/po-button/po-button.css
+++ b/src/css/components/po-button/po-button.css
@@ -245,6 +245,6 @@
 
 @media print {
   .po-button {
-    color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/src/css/components/po-disclaimer/po-disclaimer.css
+++ b/src/css/components/po-disclaimer/po-disclaimer.css
@@ -53,6 +53,6 @@
 @media print {
   .po-disclaimer-label,
   .po-disclaimer-remove {
-    color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/src/css/components/po-field/po-checkbox/po-checkbox.css
+++ b/src/css/components/po-field/po-checkbox/po-checkbox.css
@@ -1,11 +1,3 @@
-:root {
-  display: inline-block;
-  cursor: pointer;
-
-  --width-md: 24px;
-  --width-lg: 32px;
-}
-
 .po-checkbox {
   width: 24px;
   height: 24px;
@@ -20,7 +12,7 @@
   border-radius: 4px;
   min-width: 24px;
   min-height: 24px;
-
+  cursor: pointer;
   position: relative;
   font-family: PoIcon !important;
 }
@@ -67,14 +59,6 @@
   background-color: var(--color-checkbox-background-color-active-disabled);
 }
 
-:host([disabled]) {
-  cursor: not-allowed;
-}
-
-:host([disabled='false']) {
-  cursor: pointer;
-}
-
 .container-po-checkbox {
   display: flex;
   min-height: 32px;
@@ -84,6 +68,10 @@
 .po-checkbox-label {
   margin-left: 0.5rem;
   cursor: pointer;
+}
+
+.po-checkbox[aria-disabled='true'] ~ .po-checkbox-label {
+  cursor: not-allowed;
 }
 
 .po-checkbox[aria-checked='true']:before {

--- a/src/css/components/po-field/po-switch/po-switch.css
+++ b/src/css/components/po-field/po-switch/po-switch.css
@@ -145,6 +145,6 @@
 
 @media print {
   .po-switch-container {
-    color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -781,6 +781,6 @@
 
   .po-table-subtitle-circle,
   .po-table-column-label {
-    color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/src/css/components/po-tag/po-tag.css
+++ b/src/css/components/po-tag/po-tag.css
@@ -179,6 +179,6 @@
 
 @media print {
   .po-tag {
-    color-adjust: exact;
+    print-color-adjust: exact;
   }
 }


### PR DESCRIPTION
corrige cursor pointer e warnings

- testar o cursor pointer que estava pegando em toda a aplicação
- buildar e validar que não vai mais aparecer os warnings ao subir a aplicação
- testar cursor do po-checkbox, habilitado e desabilitado