### PR TITLE
docs(button-group): atualiza estilo do componente

### DIFF
--- a/src/css/components/po-button-group/po-button-group.html
+++ b/src/css/components/po-button-group/po-button-group.html
@@ -24,7 +24,7 @@
             <h5>1 botão</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 1</button>
               </div>
             </div>
           </div>
@@ -35,7 +35,7 @@
             <h5>1 botão com tooltip</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 1</button>
               </div>
               <div class="po-tooltip po-sample-tooltip">
                 <div class="po-tooltip-arrow po-arrow-top"></div>
@@ -52,10 +52,10 @@
             <h5>2 botões</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 2</button>
               </div>
             </div>
           </div>
@@ -66,13 +66,13 @@
             <h5>3 botões</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 2</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 3</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 3</button>
               </div>
             </div>
           </div>
@@ -83,13 +83,13 @@
             <h5>3 botões e 1 inativo</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 1</button>
               </div>
               <div class="po-sm-12 po-button-group po-button-group-disabled">
-                <button type="button" class="po-button" disabled>Ação 2</button>
+                <button type="button" class="po-button po-button-default" disabled>Ação 2</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Ação 3</button>
+                <button type="button" class="po-button po-button-default po-clickable">Ação 3</button>
               </div>
             </div>
           </div>
@@ -102,13 +102,13 @@
             <h5>Múltipla seleção e nenhuma opção selecionada</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 1</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 2</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 3</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 3</button>
               </div>
             </div>
           </div>
@@ -122,10 +122,10 @@
                 <button type="button" class="po-button po-clickable">Seletor 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 2</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 3</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 3</button>
               </div>
             </div>
           </div>
@@ -139,7 +139,7 @@
                 <button type="button" class="po-button po-clickable">Seletor 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 2</button>
               </div>
               <div class="po-sm-12 po-button-group po-button-group-button-selected">
                 <button type="button" class="po-button po-clickable">Seletor 3</button>
@@ -153,10 +153,10 @@
             <h5>Multipla seleção, 1 selecionada e 1 inativa</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group po-button-group-disabled">
-                <button type="button" class="po-button" disabled>Seletor 1</button>
+                <button type="button" class="po-button po-button-default" disabled>Seletor 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">Seletor 2</button>
+                <button type="button" class="po-button po-button-default po-clickable">Seletor 2</button>
               </div>
               <div class="po-sm-12 po-button-group po-button-group-button-selected">
                 <button type="button" class="po-button po-clickable">Seletor 3</button>
@@ -173,13 +173,13 @@
             <h5>Multipla seleção e nenhuma opção selecionada</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor 1</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor 1</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor 2</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor 2</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor 3</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor 3</button>
               </div>
             </div>
           </div>
@@ -190,13 +190,13 @@
             <h5>Multipla seleção e 1 opção selecionada</h5>
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor</button>
               </div>
               <div class="po-sm-12 po-button-group po-button-group-button-selected">
                 <button type="button" class="po-button po-button-sm po-clickable">Seletor</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor</button>
               </div>
             </div>
           </div>
@@ -210,10 +210,12 @@
                 <button type="button" class="po-button po-button-sm po-clickable">Seletor</button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-sm po-clickable">Seletor</button>
+                <button type="button" class="po-button po-button-default po-button-sm po-clickable">Seletor</button>
               </div>
-              <div class="po-sm-12 po-button-group po-button-group-disabled po-button-group-button-selected">
-                <button type="button" class="po-button po-button-sm" disabled>Seletor</button>
+              <div class="po-sm-12 po-button-group po-button-group-disabled">
+                <button type="button" class="po-button po-button-default po-button-default po-button-sm" disabled>
+                  Seletor
+                </button>
               </div>
             </div>
           </div>
@@ -226,19 +228,19 @@
           <div class="po-md-6">
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-user" aria-hidden="true"></span>
                   <span class="po-button-label">Ação 1</span>
                 </button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-cart" aria-hidden="true"></span>
                   <span class="po-button-label">Ação 2</span>
                 </button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-device-desktop" aria-hidden="true"></span>
                   <span class="po-button-label">Ação 3</span>
                 </button>
@@ -254,17 +256,17 @@
           <div class="po-md-2">
             <div class="po-button-group-container">
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-text-bold" aria-hidden="true"></span>
                 </button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-text-italic" aria-hidden="true"></span>
                 </button>
               </div>
               <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-clickable">
+                <button type="button" class="po-button po-button-default po-clickable">
                   <span class="po-icon po-icon-text-underline" aria-hidden="true"></span>
                 </button>
               </div>

--- a/src/css/components/po-field/po-rich-text/po-rich-text.html
+++ b/src/css/components/po-field/po-rich-text/po-rich-text.html
@@ -24,99 +24,139 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
-
-      <!-- PO-RICH-TEXT-TOOLBAR - Final -->
     </div>
-    <!-- PO-RICH-TEXT - Final -->
   </div>
-  <div class="po-field-container-bottom"></div>
+  <!-- PO-RICH-TEXT-TOOLBAR - Final -->
 </div>
+<!-- PO-RICH-TEXT - Final -->
+<div class="po-field-container-bottom"></div>
 <!-- PO-FIELD-CONTAINER - Final -->
 
 <hr />
-
 <!-- PO-FIELD-CONTAINER - Início -->
 <div class="po-field-container">
   <div class="po-field-container-title"></div>
@@ -138,7 +178,7 @@
         <div *ngIf="!isInternetExplorer" class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
             <button
-              class="po-button po-text-ellipsis po-button-group po-rich-text-toolbar-color-picker-button po-button-sm"
+              class="po-button po-button-default po-text-ellipsis po-button-group po-rich-text-toolbar-color-picker-button po-button-sm"
               [disabled]="readonly"
               [p-tooltip]="literals.textColor"
               [attr.aria-label]="literals.textColor"
@@ -235,86 +275,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -372,86 +454,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -485,86 +609,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -593,90 +759,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button
-                type="button"
-                class="po-button po-text-ellipsis"
-                onClick="document.getElementsByClassName('po-modal')[0].style.display = 'block';"
-              >
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
 
@@ -706,90 +910,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button
-                type="button"
-                class="po-button po-text-ellipsis"
-                onClick="document.getElementsByClassName('po-modal')[1].style.display = 'block';"
-              >
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
 
@@ -821,90 +1063,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button">
-              <button
-                type="button"
-                class="po-button po-text-ellipsis"
-                onClick="document.getElementsByClassName('po-modal')[1].style.display = 'block';"
-              >
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
 
@@ -936,90 +1216,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button
-                type="button"
-                class="po-button po-text-ellipsis"
-                onClick="document.getElementsByClassName('po-modal')[1].style.display = 'block';"
-              >
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
 
@@ -1051,90 +1369,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button
-                type="button"
-                class="po-button po-text-ellipsis"
-                onClick="document.getElementsByClassName('po-modal')[1].style.display = 'block';"
-              >
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -1165,86 +1521,128 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis">
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
 
@@ -1280,86 +1678,166 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-text-bold"></span>
-              </button>
+          <po-button-group p-toggle="multiple">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-text-ellipsis po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-text-italic"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-text-underline"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
           <div class="po-rich-text-toolbar-color-picker-container">
-            <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button" disabled>
-              <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" disabled />
+            <button
+              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+              disabled
+              tabindex="-1"
+            >
+              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
             </button>
           </div>
         </div>
-
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group po-button-group-button-selected">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-align-left"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-left"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" disabled tabindex="-1">
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-center"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-right"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i class="po-icon po-icon-align-justify"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-align-center"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-align-right"></span>
-              </button>
-            </div>
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-align-justify"></span>
-              </button>
-            </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-list"></span>
-              </button>
+          <po-button-group p-toggle="single">
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon-link"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <div class="po-button-group-container">
-            <div class="po-sm-12 po-button-group">
-              <button type="button" class="po-button po-text-ellipsis" disabled>
-                <span class="po-icon po-icon po-icon-picture"></span>
-              </button>
+          <po-button-group>
+            <div class="po-button-group-container">
+              <po-button class="po-sm-12 po-button-group">
+                <button
+                  type="button"
+                  class="po-button po-text-ellipsis po-button-default po-button-sm"
+                  disabled
+                  tabindex="-1"
+                >
+                  <po-icon class="po-button-icon">
+                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                  </po-icon>
+                </button>
+              </po-button>
             </div>
-          </div>
+          </po-button-group>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -1389,86 +1867,128 @@
         <!-- PO-RICH-TEXT-TOOLBAR - Início -->
         <div class="po-rich-text-toolbar">
           <div class="po-rich-text-toolbar-button-align">
-            <div class="po-button-group-container">
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-text-bold"></span>
-                </button>
+            <po-button-group p-toggle="multiple">
+              <div class="po-button-group-container">
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
+                    </po-icon>
+                  </button>
+                </po-button>
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
+                    </po-icon>
+                  </button>
+                </po-button>
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
               </div>
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-text-italic"></span>
-                </button>
-              </div>
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-text-underline"></span>
-                </button>
-              </div>
-            </div>
+            </po-button-group>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
             <div class="po-rich-text-toolbar-color-picker-container">
-              <button class="po-button po-text-ellipsis po-rich-text-toolbar-color-picker-button">
-                <input class="po-rich-text-toolbar-color-picker-input" type="color" value="#000000" />
+              <button
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input type="color" class="po-rich-text-toolbar-color-picker-input" />
               </button>
             </div>
           </div>
-
           <div class="po-rich-text-toolbar-button-align">
-            <div class="po-button-group-container">
-              <div class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-align-left"></span>
-                </button>
+            <po-button-group p-toggle="single">
+              <div class="po-button-group-container">
+                <po-button class="po-sm-12 po-button-group">
+                  <button
+                    type="button"
+                    class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                    tabindex="-1"
+                  >
+                    <po-icon class="po-button-icon">
+                      <i class="po-icon po-icon-align-left"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
+
+                <po-button class="po-sm-12 po-button-group">
+                  <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i class="po-icon po-icon-align-center"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
+
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i class="po-icon po-icon-align-right"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i class="po-icon po-icon-align-justify"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
               </div>
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-align-center"></span>
-                </button>
-              </div>
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-align-right"></span>
-                </button>
-              </div>
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-align-justify"></span>
-                </button>
-              </div>
-            </div>
+            </po-button-group>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <div class="po-button-group-container">
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-list"></span>
-                </button>
+            <po-button-group p-toggle="single">
+              <div class="po-button-group-container">
+                <po-button class="po-sm-12 po-button-group">
+                  <button
+                    type="button"
+                    class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
+                    tabindex="-1"
+                  >
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-list"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
               </div>
-            </div>
+            </po-button-group>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <div class="po-button-group-container">
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon-link"></span>
-                </button>
+            <po-button-group>
+              <div class="po-button-group-container">
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-link"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
               </div>
-            </div>
+            </po-button-group>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <div class="po-button-group-container">
-              <div class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis">
-                  <span class="po-icon po-icon po-icon-picture"></span>
-                </button>
+            <po-button-group>
+              <div class="po-button-group-container">
+                <po-button class="po-sm-12 po-button-group">
+                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                    <po-icon class="po-button-icon">
+                      <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
+                    </po-icon>
+                  </button>
+                </po-button>
               </div>
-            </div>
+            </po-button-group>
           </div>
         </div>
         <!-- PO-RICH-TEXT-TOOLBAR - Final -->

--- a/src/css/components/po-field/po-rich-text/po-rich-text.html
+++ b/src/css/components/po-field/po-rich-text/po-rich-text.html
@@ -4,6 +4,10 @@
     outline: none;
     color: #c64840;
   }
+
+  .align-initial-color-picker {
+    vertical-align: initial;
+  }
 </style>
 
 <!-- PO-FIELD-CONTAINER - Início -->
@@ -24,128 +28,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -185,7 +160,7 @@
             >
               <input
                 #colorPickerInput
-                class="po-rich-text-toolbar-color-picker-input"
+                class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
                 type="color"
                 [disabled]="readonly"
                 (change)="changeTextColor($event.target.value)"
@@ -275,128 +250,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -454,128 +400,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -609,128 +526,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -759,128 +647,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -910,128 +769,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1063,128 +893,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1216,128 +1017,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1369,128 +1141,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -1521,128 +1264,99 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group po-button-group-button-selected">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group po-button-group-button-selected">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -1678,166 +1392,145 @@
       <!-- PO-RICH-TEXT-TOOLBAR - Início -->
       <div class="po-rich-text-toolbar">
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="multiple">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-text-ellipsis po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-button-default po-text-ellipsis po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-text-bold"></span>
+              </button>
             </div>
-          </po-button-group>
-        </div>
 
-        <div class="po-rich-text-toolbar-button-align">
-          <div class="po-rich-text-toolbar-color-picker-container">
-            <button
-              class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-              disabled
-              tabindex="-1"
-            >
-              <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-            </button>
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-text-italic"></span>
+              </button>
+            </div>
+
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-text-underline"></span>
+              </button>
+            </div>
           </div>
         </div>
+
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-left"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button class="po-button po-text-ellipsis po-button-default po-button-sm" disabled tabindex="-1">
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-center"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-right"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i class="po-icon po-icon-align-justify"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-rich-text-toolbar-color-picker-container">
+              <button
+                type="button"
+                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                disabled
+                tabindex="-1"
+              >
+                <input
+                  class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                  type="color"
+                  value="#000000"
+                />
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group p-toggle="single">
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-button-default po-text-ellipsis po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-align-left"></span>
+              </button>
             </div>
-          </po-button-group>
+
+            <div class="po-sm-12 po-button-group">
+              <button class="po-button po-text-ellipsis po-button-default po-button-sm" disabled tabindex="-1">
+                <span class="po-icon po-icon-align-center"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-align-right"></span>
+              </button>
+            </div>
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-align-justify"></span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-list"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
         </div>
 
         <div class="po-rich-text-toolbar-button-align">
-          <po-button-group>
-            <div class="po-button-group-container">
-              <po-button class="po-sm-12 po-button-group">
-                <button
-                  type="button"
-                  class="po-button po-text-ellipsis po-button-default po-button-sm"
-                  disabled
-                  tabindex="-1"
-                >
-                  <po-icon class="po-button-icon">
-                    <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                  </po-icon>
-                </button>
-              </po-button>
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon-link"></span>
+              </button>
             </div>
-          </po-button-group>
+          </div>
+        </div>
+
+        <div class="po-rich-text-toolbar-button-align">
+          <div class="po-button-group-container">
+            <div class="po-sm-12 po-button-group">
+              <button
+                type="button"
+                class="po-button po-text-ellipsis po-button-default po-button-sm"
+                disabled
+                tabindex="-1"
+              >
+                <span class="po-icon po-icon po-icon-picture"></span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <!-- PO-RICH-TEXT-TOOLBAR - Final -->
@@ -1867,128 +1560,99 @@
         <!-- PO-RICH-TEXT-TOOLBAR - Início -->
         <div class="po-rich-text-toolbar">
           <div class="po-rich-text-toolbar-button-align">
-            <po-button-group p-toggle="multiple">
-              <div class="po-button-group-container">
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-text-bold"></i>
-                    </po-icon>
-                  </button>
-                </po-button>
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-text-italic"></i>
-                    </po-icon>
-                  </button>
-                </po-button>
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-text-underline"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
+            <div class="po-button-group-container">
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-text-bold"></span>
+                </button>
               </div>
-            </po-button-group>
-          </div>
 
-          <div class="po-rich-text-toolbar-button-align">
-            <div class="po-rich-text-toolbar-color-picker-container">
-              <button
-                class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                tabindex="-1"
-              >
-                <input type="color" class="po-rich-text-toolbar-color-picker-input" />
-              </button>
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-text-italic"></span>
+                </button>
+              </div>
+
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-text-underline"></span>
+                </button>
+              </div>
             </div>
           </div>
+
           <div class="po-rich-text-toolbar-button-align">
-            <po-button-group p-toggle="single">
-              <div class="po-button-group-container">
-                <po-button class="po-sm-12 po-button-group">
-                  <button
-                    type="button"
-                    class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
-                    tabindex="-1"
-                  >
-                    <po-icon class="po-button-icon">
-                      <i class="po-icon po-icon-align-left"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
-
-                <po-button class="po-sm-12 po-button-group">
-                  <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i class="po-icon po-icon-align-center"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
-
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i class="po-icon po-icon-align-right"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i class="po-icon po-icon-align-justify"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
+            <div class="po-button-group-container">
+              <div class="po-rich-text-toolbar-color-picker-container">
+                <button
+                  type="button"
+                  class="po-button po-button-default po-button-sm po-text-ellipsis po-rich-text-toolbar-color-picker-button"
+                  tabindex="-1"
+                >
+                  <input
+                    class="po-rich-text-toolbar-color-picker-input align-initial-color-picker"
+                    type="color"
+                    value="#000000"
+                  />
+                </button>
               </div>
-            </po-button-group>
+            </div>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <po-button-group p-toggle="single">
-              <div class="po-button-group-container">
-                <po-button class="po-sm-12 po-button-group">
-                  <button
-                    type="button"
-                    class="po-button po-text-ellipsis po-button-default po-button-sm po-rich-text-toolbar-color-picker-button"
-                    tabindex="-1"
-                  >
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-list"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
+            <div class="po-button-group-container">
+              <div class="po-sm-12 po-button-group po-button-group-button-selected">
+                <button type="button" class="po-button po-button-default po-text-ellipsis po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-align-left"></span>
+                </button>
               </div>
-            </po-button-group>
+
+              <div class="po-sm-12 po-button-group">
+                <button class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-align-center"></span>
+                </button>
+              </div>
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-align-right"></span>
+                </button>
+              </div>
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-align-justify"></span>
+                </button>
+              </div>
+            </div>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <po-button-group>
-              <div class="po-button-group-container">
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-link"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
+            <div class="po-button-group-container">
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-list"></span>
+                </button>
               </div>
-            </po-button-group>
+            </div>
           </div>
 
           <div class="po-rich-text-toolbar-button-align">
-            <po-button-group>
-              <div class="po-button-group-container">
-                <po-button class="po-sm-12 po-button-group">
-                  <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
-                    <po-icon class="po-button-icon">
-                      <i aria-hidden="true" class="po-icon po-icon-picture"> </i>
-                    </po-icon>
-                  </button>
-                </po-button>
+            <div class="po-button-group-container">
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon-link"></span>
+                </button>
               </div>
-            </po-button-group>
+            </div>
+          </div>
+
+          <div class="po-rich-text-toolbar-button-align">
+            <div class="po-button-group-container">
+              <div class="po-sm-12 po-button-group">
+                <button type="button" class="po-button po-text-ellipsis po-button-default po-button-sm" tabindex="-1">
+                  <span class="po-icon po-icon po-icon-picture"></span>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
         <!-- PO-RICH-TEXT-TOOLBAR - Final -->


### PR DESCRIPTION
Atualiza estilo dos componentes rich-text e button-group no app do CDN

Fixes DTHFUI-6023

Como testar
rodar o 'npm run watch' no po-style e depois em outro terminal na mesma pasta rodar o live-server