### PR TITLE
fix(rich-text): corrige o alinhamento dos botões

### DIFF
--- a/src/css/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.css
+++ b/src/css/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.css
@@ -18,6 +18,7 @@
   border: var(--border-rich-text-toolbar-border);
   border-radius: 0 0 3px 3px;
   border-top: none;
+  display: flex;
   min-height: var(--rich-text-toolbar-min-height);
   min-width: var(--rich-text-toolbar-min-width);
   padding: 16px 0 0 16px;


### PR DESCRIPTION
**RICH-TEXT**

Corrige o alinhamento dos botões no navegador Firefox.

Fixes DTHFUI-5598