### PR TITLE
feat(table): reutiliza o componente po-radio

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -174,6 +174,10 @@
   height: var(--table-row-height);
 }
 
+.po-table .po-table-row po-radio {
+  padding-top: 3px;
+}
+
 .po-table-striped .po-table-group-row:nth-child(odd) {
   background-color: var(--color-table-background-color-row-strip);
 }


### PR DESCRIPTION
Reutiliza o componente `po-radio` ao utilizar a funcionalidade de seleção única

DTHFUI-7124