### PR TITLE
fix(tooltip): corrige quebra de linha

### DIFF
--- a/src/css/components/po-tooltip/po-tooltip.css
+++ b/src/css/components/po-tooltip/po-tooltip.css
@@ -15,6 +15,7 @@
   position: fixed;
   z-index: 1000;
   opacity: 0;
+  display: block;
 }
 
 .po-tooltip-arrow {


### PR DESCRIPTION
Corrige quebra de linha na tooltip com texto grande

fixes DTHFUI-7109

testar app:

```
<po-page-dynamic-table
  p-title="Teste"
  p-service-api="https://po-sample-api.fly.dev/v1/people"
  [p-fields]="[{ property: 'id' }, { property: 'name' }]"
  p-quick-search-width="6"
  p-quick-search-value="35220553113791000637570000073806291214427288"
>
</po-page-dynamic-table>

<po-button p-label="Open Tooltip" p-tooltip="35220553113791000637570000073806291214427288"> </po-button>


```