### PR TITLE
fix(table): ajusta largura do template details

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -639,3 +639,7 @@ span.po-table-header-icon-ascending svg {
     print-color-adjust: exact;
   }
 }
+
+.po-table-row-template-container {
+  max-width: 1rem;
+}


### PR DESCRIPTION
Comportamento atual:
Ao acessar o details do po-table e a largura do mesmo ultrapassa o tamanho da tela ocorre a quebra do po-table por inteiro e não só do details, assim criando um scroll horizontal para toda a tabela e desrespeitando os valores de largura das colunas da tabela principal, assim quebrando o layout proposto para a tela.

Comportamento esperado:
Como nas versões anteriores do PO-UI, como por exemplo a versão 15.9.0(versão anterior utilizado no projeto), onde quando a largura do detail ultrapassava a largura da tela, era criado um scroll horizontal dentro do próprio detail, respeitando os valores estipulados nas colunas tanto no detail quanto na tabela principal.

FIX DTHFUI-8133