### PR TITLE
refactor(components): remove propriedades depreciadas

### DIFF
--- a/src/css/components/po-table/po-table-column-manager/po-table-column-manager.css
+++ b/src/css/components/po-table/po-table-column-manager/po-table-column-manager.css
@@ -96,8 +96,7 @@
   margin: 4px 0;
 }
 
-.po-container-icons-arrows-columns-manager .po-button,
-.po-container-icons-arrows-columns-manager .po-button:not(.po-button-sm) {
+.po-container-icons-arrows-columns-manager .po-button {
   margin: 0;
   padding: 0;
 }

--- a/src/css/services/po-notification/po-toaster/po-toaster.css
+++ b/src/css/services/po-notification/po-toaster/po-toaster.css
@@ -211,7 +211,7 @@ po-toaster {
 }
 
 @media screen and (max-width: 1366px) {
-  .po-toaster .po-button:not(.po-button-sm) {
+  .po-toaster .po-button {
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }


### PR DESCRIPTION
Foi removida a propriedade p-small do componente.

Fixes DTHFUI-8043

BREAKING CHANGE: removida propriedade p-small

Por regras de acessibilidade o botão não terá mais um tamanho menor do que 44px e por isso a propriedade será depreciada. Saiba mais