### PR TITLE
feat(icon): inclui dicionário de tokens

### DIFF
--- a/src/css/commons/po-icon/po-icon-base.css
+++ b/src/css/commons/po-icon/po-icon-base.css
@@ -8,6 +8,10 @@
   font-style: normal;
 }
 
+po-icon i {
+  font-style: normal;
+}
+
 [class^='po-icon'],
 [class*=' po-icon'] {
   /* use !important to prevent issues with browser extensions that change fonts */

--- a/src/css/components/po-avatar/po-avatar.css
+++ b/src/css/components/po-avatar/po-avatar.css
@@ -19,26 +19,31 @@
 .po-avatar.po-avatar-xs {
   height: 24px;
   width: 24px;
+  line-height: 12px;
 }
 
 .po-avatar.po-avatar-sm {
   height: 32px;
   width: 32px;
+  line-height: 16px;
 }
 
 .po-avatar.po-avatar-md {
   height: 64px;
   width: 64px;
+  line-height: 32px;
 }
 
 .po-avatar.po-avatar-lg {
   height: 96px;
   width: 96px;
+  line-height: 48px;
 }
 
 .po-avatar.po-avatar-xl {
   height: 144px;
   width: 144px;
+  line-height: 72px;
 }
 
 .po-avatar-default-icon {

--- a/src/css/components/po-breadcrumb/po-breadcrumb.css
+++ b/src/css/components/po-breadcrumb/po-breadcrumb.css
@@ -97,7 +97,7 @@
   white-space: nowrap;
 }
 
-.po-breadcrumb-icon-more .po-icon-more-vert {
+.po-breadcrumb-icon-more i {
   color: var(--color-breadcrumb-color-item, var(--color));
 }
 

--- a/src/css/components/po-button/po-button.css
+++ b/src/css/components/po-button/po-button.css
@@ -198,10 +198,6 @@ po-button {
   vertical-align: -0.05rem;
 }
 
-.po-button .po-button-icon > :first-child:not(.po-fonts-icon):not(.po-icon) {
-  vertical-align: -0.1rem;
-}
-
 .po-button .po-button-icon > :first-child:not(.po-fonts-icon):not(.po-icon) path {
   fill: var(--color);
 }

--- a/src/css/components/po-calendar/po-calendar.css
+++ b/src/css/components/po-calendar/po-calendar.css
@@ -80,6 +80,16 @@
   right: 16px;
 }
 
+.po-calendar-header po-icon.po-calendar-header-left,
+.po-calendar-header po-icon.po-calendar-header-right {
+  line-height: 0;
+}
+
+.po-calendar-header .po-calendar-header-left i,
+.po-calendar-header .po-calendar-header-right i {
+  line-height: 32px;
+}
+
 .po-calendar-header .po-calendar-header-title {
   font-family: var(--font-family-default-bold), sans-serif;
   font-size: 16px;

--- a/src/css/components/po-field/po-combo/po-combo.css
+++ b/src/css/components/po-field/po-combo/po-combo.css
@@ -78,8 +78,7 @@
   justify-content: center;
 }
 
-.po-combo-container-content .po-field-icon.po-icon.po-icon-arrow-down,
-.po-combo-container-content .po-field-icon.po-icon.po-icon-arrow-up {
+.po-combo-container-content .po-combo-arrow .po-field-icon > i {
   height: 2.75rem;
   width: 2.75rem;
   border-top: 1px solid transparent;
@@ -92,8 +91,8 @@
   justify-content: center;
 }
 
-.po-combo-input[disabled='true'] ~ .po-field-icon-container-right .po-field-icon-disabled.po-icon.po-icon-arrow-down,
-.po-combo-input:disabled ~ .po-field-icon-container-right .po-field-icon-disabled.po-icon.po-icon-arrow-down {
+.po-combo-input[disabled='true'] ~ .po-field-icon-container-right .po-field-icon-disabled i,
+.po-combo-input:disabled ~ .po-field-icon-container-right .po-field-icon-disabled i {
   height: 2.75rem;
   width: 2.75rem;
   border-top: 1px solid transparent;
@@ -119,40 +118,34 @@
   outline-width: var(--outline-width-focus-visible);
 }
 
-.po-combo-clean:focus .po-icon.po-field-icon.po-icon-clear-content,
-.po-combo-clean:focus .po-icon.po-field-icon.po-icon-clear-content:hover {
+.po-combo-clean:focus > i.po-field-icon,
+.po-combo-clean:focus > i.po-field-icon:hover {
   border-color: var(--color);
 }
 
-.po-combo-input:focus ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-down,
-.po-combo-input:focus ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up {
+.po-combo-input:focus ~ .po-field-icon-container-right .po-field-icon > i {
   border-color: var(--color-focused);
 }
 
-.po-combo-input:focus:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-down,
-.po-combo-input:focus:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up {
+.po-combo-input:focus:hover ~ .po-field-icon-container-right .po-field-icon > i {
   border-color: var(--color-hover);
 }
 
-.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-down,
-.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up {
+.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon > i {
   border-left-color: var(--color-hover);
 }
 
-.po-combo-container-content span:hover.po-field-icon.po-icon.po-icon-arrow-down.po-icon-input {
+.po-combo-container-content .po-field-icon > i.po-icon-input:hover {
   background: var(--background-hover);
   border-color: var(--color);
 }
 
-.po-combo-container-content span:hover.po-field-icon.po-icon.po-icon-arrow-up.po-icon-input,
+.po-combo-container-content .po-field-icon > i.po-icon-input:hover,
 .po-combo-container-content
   .po-combo-input:focus
   ~ .po-field-icon-container-right
-  span:hover.po-field-icon.po-icon.po-icon-arrow-up.po-icon-input,
-.po-combo-container-content
-  .po-combo-input:focus
-  ~ .po-field-icon-container-right
-  span:hover.po-field-icon.po-icon.po-icon-arrow-down.po-icon-input {
+  .po-field-icon
+  > i.po-icon-input:hover {
   background: var(--background-hover);
   border-color: var(--color-focused);
 }
@@ -160,12 +153,13 @@
 .po-combo-container-content
   .po-combo-input-focus
   ~ .po-field-icon-container-right
-  span:hover.po-field-icon.po-icon.po-icon-arrow-up.po-icon-input {
+  .po-field-icon
+  > i.po-icon-input:hover {
   background: var(--background-hover);
   border-color: var(--color-hover);
 }
 
-.po-combo-container-content .po-field-icon.po-icon.po-icon-clear-content {
+.po-combo-container-content .po-combo-clean .po-field-icon > i {
   height: 2.75rem;
   width: 2.75rem;
   display: flex;
@@ -173,28 +167,25 @@
   justify-content: center;
 }
 
-.po-combo-container-content:focus-within .po-field-icon.po-icon.po-icon-clear-content {
+.po-combo-container-content:focus-within .po-combo-clean .po-field-icon > i {
   border-color: var(--color-focused);
 }
 
-.po-border-focused.po-icon.po-field-icon.po-icon-clear-content:hover {
+.po-combo-clean .po-border-focused.po-field-icon > i:hover {
   border-color: var(--color-focused);
 }
 
-.po-combo-input:hover
-  ~ .po-field-icon-container-right
-  .po-field-icon.po-icon.po-icon-arrow-down.po-combo-default-border,
-.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up.po-combo-default-border,
-.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon.po-icon.po-icon-clear-content {
+.po-combo-input:hover ~ .po-field-icon-container-right .po-field-icon > i.po-combo-default-border,
+.po-combo-input:hover ~ .po-field-icon-container-right .po-combo-clean .po-field-icon > i {
   border-color: var(--color-hover);
 }
 
-.po-field-icon-container-right .po-field-icon.po-icon.po-combo-background-arrow-up.po-icon-arrow-up {
+.po-field-icon-container-right > .po-field-icon > i.po-combo-background-arrow-up {
   background: var(--background-hover);
   border-color: var(--color-focused);
 }
 
-.po-icon.po-field-icon.po-icon-clear-content:hover {
+.po-combo-clean .po-field-icon > i:hover {
   background: var(--background-hover);
   border-top: 1px solid var(--color);
   border-bottom: 1px solid var(--color);
@@ -217,35 +208,15 @@
 }
 
 po-combo.ng-invalid.ng-dirty .po-combo-input,
-po-combo.ng-invalid.ng-dirty
-  .po-combo-input:focus
-  ~ .po-field-icon-container-right
-  .po-field-icon.po-icon.po-icon-arrow-down,
-po-combo.ng-invalid.ng-dirty
-  .po-combo-input:focus
-  ~ .po-field-icon-container-right
-  .po-field-icon.po-icon.po-icon-arrow-up,
-po-combo.ng-invalid.ng-dirty
-  .po-combo-input:focus:hover
-  ~ .po-field-icon-container-right
-  .po-field-icon.po-icon.po-icon-arrow-down,
-po-combo.ng-invalid.ng-dirty
-  .po-combo-input:focus:hover
-  ~ .po-field-icon-container-right
-  .po-field-icon.po-icon.po-icon-arrow-up,
-po-combo.ng-invalid.ng-dirty .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-down,
-po-combo.ng-invalid.ng-dirty .po-field-icon-container-right .po-field-icon.po-icon.po-icon-arrow-up,
-po-combo.ng-invalid.ng-dirty .po-field-icon-container-right .po-field-icon.po-icon.po-icon-clear-content,
+po-combo.ng-invalid.ng-dirty .po-combo-input:focus ~ .po-field-icon-container-right .po-field-icon > i,
+po-combo.ng-invalid.ng-dirty .po-combo-input:focus:hover ~ .po-field-icon-container-right .po-field-icon > i,
+po-combo.ng-invalid.ng-dirty .po-field-icon-container-right .po-field-icon > i,
 po-combo.ng-invalid.ng-dirty
   .po-combo-container-content
   .po-combo-input:focus
   ~ .po-field-icon-container-right
-  span:hover.po-field-icon.po-icon.po-icon-arrow-down.po-icon-input,
-po-combo.ng-invalid.ng-dirty
-  .po-combo-container-content
-  .po-combo-input:focus
-  ~ .po-field-icon-container-right
-  span:hover.po-field-icon.po-icon.po-icon-arrow-up.po-icon-input {
+  .po-field-icon
+  > i.po-icon-input:hover {
   border-color: var(--color-error);
   color: var(--color-error);
 }

--- a/src/css/components/po-field/po-datepicker-range/po-datepicker-range.css
+++ b/src/css/components/po-field/po-datepicker-range/po-datepicker-range.css
@@ -44,10 +44,6 @@ div.po-datepicker-range-field-focused {
   width: 10px;
 }
 
-.po-datepicker-range-icon .po-icon-calendar {
-  cursor: default;
-}
-
 .po-datepicker-range-input {
   background-color: transparent;
   border: none;

--- a/src/css/components/po-field/po-datepicker/po-datepicker.css
+++ b/src/css/components/po-field/po-datepicker/po-datepicker.css
@@ -30,6 +30,6 @@
   z-index: 11;
 }
 
-.po-datepicker-button .po-icon-calendar {
+.po-datepicker-button i {
   font-size: 1.5rem;
 }

--- a/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.css
+++ b/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.css
@@ -52,7 +52,7 @@ po-field-container-bottom .po-field-container-bottom {
   position: relative;
 }
 
-.po-field-container-error-item .po-icon-exclamation {
+.po-field-container-error-item i {
   font-size: 16px;
   position: absolute;
   top: 50%;

--- a/src/css/components/po-field/po-field-icon/po-field-icon.css
+++ b/src/css/components/po-field/po-field-icon/po-field-icon.css
@@ -31,7 +31,11 @@
   cursor: pointer;
 }
 
-.po-field-icon:not(.po-icon-eye-off, .po-field-icon-disabled) {
+.po-field-icon-right {
+  float: right;
+}
+
+.po-field-icon:not(.po-field-icon-disabled) {
   color: var(--color-brand-01-dark);
 }
 

--- a/src/css/components/po-field/po-input/po-input.css
+++ b/src/css/components/po-field/po-input/po-input.css
@@ -59,8 +59,7 @@
   cursor: not-allowed;
 }
 
-.po-field-icon.po-icon-input:not(.po-icon-eye-off),
-po-clean.po-icon-input span.po-field-icon {
+po-clean.po-icon-input i.po-field-icon {
   color: var(--color-brand-01-dark);
 }
 

--- a/src/css/components/po-menu/po-menu-filter/po-menu-filter.css
+++ b/src/css/components/po-menu/po-menu-filter/po-menu-filter.css
@@ -11,6 +11,10 @@
   text-decoration: none;
 }
 
+.po-menu-filter-icon > i {
+  line-height: 33px;
+}
+
 .po-menu-filter-search-icon-container {
   left: 16px;
   width: 2.75em;
@@ -79,7 +83,7 @@
   justify-content: center;
   align-items: center;
 
-  .po-icon-close {
+  i.po-field-icon {
     color: var(--color-clear);
   }
 }

--- a/src/css/components/po-modal/po-modal.css
+++ b/src/css/components/po-modal/po-modal.css
@@ -91,7 +91,7 @@
   justify-content: space-between;
 }
 
-.po-modal-header .po-icon.po-icon-close:before {
+.po-modal-header i:before {
   font-size: 2rem;
 }
 

--- a/src/css/components/po-page/po-page-login/po-page-login.css
+++ b/src/css/components/po-page/po-page-login/po-page-login.css
@@ -194,7 +194,7 @@
   padding: 0;
 }
 
-.po-page-login-body .po-field-icon.po-icon-info {
+.po-page-login-body i.po-field-icon {
   cursor: default;
   text-align: left;
 }

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -251,7 +251,7 @@
   width: 56px;
 }
 
-.po-table-column-actions .po-icon.po-icon-more {
+.po-table-column-actions i {
   color: var(--color-table-color-header, var(--color));
   display: block;
   font-size: 1.5rem;
@@ -484,8 +484,7 @@
   pointer-events: none;
 }
 
-.po-table-column-detail-toggle .po-icon-arrow-down,
-.po-table-column-detail-toggle .po-icon-arrow-up {
+.po-table-column-detail-toggle i {
   color: var(--color-table-color-header, var(--color));
   display: block;
   font-size: 1.5rem;

--- a/src/css/components/po-toolbar/po-toolbar.css
+++ b/src/css/components/po-toolbar/po-toolbar.css
@@ -58,6 +58,10 @@
   vertical-align: middle;
 }
 
+.po-toolbar-notification po-icon {
+  line-height: 0;
+}
+
 .po-toolbar-notification-badge {
   @apply --font-toolbar-font-bagde;
   background-color: var(--color-toolbar-background-color-badge);

--- a/src/css/components/po-tree-view/po-tree-view-item-header.css
+++ b/src/css/components/po-tree-view/po-tree-view-item-header.css
@@ -24,6 +24,7 @@
   margin-right: 8px;
   overflow: hidden;
   vertical-align: top;
+  line-height: 0px;
 }
 
 .po-tree-view-item-header-button::-moz-focus-inner {


### PR DESCRIPTION
PO_ICON

DTHFUI-8700

PR Checklist [Revisor]

 [Padrão de Commit](https://github.com/po-ui/po-angular/blob/master/CONTRIBUTING.md) (Coeso, de acordo com o que está sendo realizado)
 [Código](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md) (Boas práticas, nome de variavéis/métodos, etc.)
 Testes unitários (Cobre a situação implementada e coverage está mantido)
 [Documentação](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#documenta%C3%A7%C3%A3o) (Clara, objetiva e com exemplos caso necessário)
 [Samples](https://github.com/po-ui/po-angular/blob/master/STYLEGUIDE.md#samples) (A implementação possui exemplo no Labs/Caso de uso)
 Rodado em navegadores suportados (Chrome, FireFox, Edge)
Qual o comportamento atual?
Po-icon recebe o nome de um ícone através do parâmetro p-icon, endo este valor fixo, exemplo: po-icon-news.

Qual o novo comportamento?
Po-icon passa a receber também um token, desde que este esteja presente em po-icon.service. Exemplo, ICON_NEWS.

Simulação
Anexo na PR https://github.com/po-ui/po-angular/pull/2040
