### PR TITLE
feat(toaster): criação do componente po-toaster

### DIFF
--- a/docs/guides/icons.md
+++ b/docs/guides/icons.md
@@ -2,6 +2,70 @@
 [comment]: # (@label Biblioteca de ícones)
 [comment]: # (@link guides/icons)
 
+### Adicionamos suporte à Biblioteca de ícones Phosphor (v2.1)
+
+A partir da versão 17.15.0, disponibilizado suporte à biblioteca de ícones [Phosphor](https://phosphoricons.com/) (no estilo **regular**).
+
+#### Como Usar?
+
+``` html
+<po-input p-icon="ph ph-user" p-label="PO input"></po-input>
+```
+
+Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
+
+``` html
+<po-input [p-icon]="template" p-label="input template"></po-input>
+...
+<ng-template #template>
+ <i class="ph ph-arrow-fat-line-down"></i>
+</ng-template>
+```
+
+#### Ícones padrões
+
+Alguns elementos do PO-UI apresentam ícones internos, como por exemplo o `po-progress` (consulte https://po-ui.io/documentation/po-progress). 
+Esses ícones são os ícones padrões do po-ui.
+
+Atualmente, estamos usando a biblioteca `PoIcon` para esses ícones, mas agora é possível substituir os ícones padrões pela biblioteca `Phosphor`.
+
+Para isso, faça as seguintes alterações no arquivo `app.module`:
+
+``` javascript
+import { ICONS_DICTIONARY, PhosphorIconDictionary, PoModule } from '@po-ui/ng-components';
+
+@NgModule({
+  ...
+  providers: [
+    {
+      provide: ICONS_DICTIONARY,
+      useValue: PhosphorIconDictionary,
+    },
+  ],
+  ...
+})
+export class AppModule {}
+```
+
+Ou no arquivo `app.config.ts` para projeto do tipo `standalone`: 
+
+``` javascript
+import { ICONS_DICTIONARY, PhosphorIconDictionary, PoModule } from '@po-ui/ng-components';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    ...
+    {
+      provide: ICONS_DICTIONARY,
+      useValue: PhosphorIconDictionary,
+    },
+  ],
+}
+export class AppModule {}
+```
+
+----------------------------------------
+
 O PO conta com uma Biblioteca de ícones disponibilizada pela equipe de UX.
 
 ### Como Usar?
@@ -1244,65 +1308,3 @@ O PO conta com uma Biblioteca de ícones disponibilizada pela equipe de UX.
   </li>
 
 </ul>
-
-### Adicionamos suporte à biblioteca de ícones Phosphor (v2.1)
-
-A partir da versão 17.15.0, disponibilizado suporte à biblioteca de ícones [Phosphor](https://phosphoricons.com/) (no estilo **regular**).
-
-#### Como Usar?
-
-``` html
-<po-input p-icon="ph ph-user" p-label="PO input"></po-input>
-```
-
-Outra opção seria a customização do ícone através do `TemplateRef`, conforme exemplo abaixo:
-
-``` html
-<po-input [p-icon]="template" p-label="input template"></po-input>
-...
-<ng-template #template>
- <i class="ph ph-arrow-fat-line-down"></i>
-</ng-template>
-```
-
-#### Ícones padrões
-
-Alguns elementos do PO-UI apresentam ícones internos, como por exemplo o `po-progress` (consulte https://po-ui.io/documentation/po-progress). 
-Esses ícones são os ícones padrões do po-ui.
-
-Atualmente, estamos usando a biblioteca `PoIcon` para esses ícones, mas agora é possível substituir os ícones padrões pela biblioteca `Phosphor`.
-
-Para isso, faça as seguintes alterações no arquivo `app.module`:
-
-``` javascript
-import { ICONS_DICTIONARY, PhosphorIconDictionary, PoModule } from '@po-ui/ng-components';
-
-@NgModule({
-  ...
-  providers: [
-    {
-      provide: ICONS_DICTIONARY,
-      useValue: PhosphorIconDictionary,
-    },
-  ],
-  ...
-})
-export class AppModule {}
-```
-
-Ou no arquivo `app.config.ts` para projeto do tipo `standalone`: 
-
-``` javascript
-import { ICONS_DICTIONARY, PhosphorIconDictionary, PoModule } from '@po-ui/ng-components';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    ...
-    {
-      provide: ICONS_DICTIONARY,
-      useValue: PhosphorIconDictionary,
-    },
-  ],
-}
-export class AppModule {}
-```

--- a/src/css/services/po-notification/po-toaster/po-toaster.css
+++ b/src/css/services/po-notification/po-toaster/po-toaster.css
@@ -3,11 +3,6 @@
     font-size: 1.5rem;
     font-weight: 700;
   }
-
-  --font-toaster-message: {
-    color: var(--color-neutral-dark-90);
-    line-height: 150%;
-  }
 }
 
 po-toaster {
@@ -25,7 +20,6 @@ po-toaster {
   border-width: var(--border-width-sm);
   border-style: solid;
 
-  display: flex;
   align-items: stretch;
   overflow: hidden;
   -webkit-background-clip: padding-box;
@@ -39,6 +33,10 @@ po-toaster {
   transition-timing-function: linear;
 }
 
+.po-toaster:not(.po-toaster-inline) {
+  display: flex;
+}
+
 .po-toaster-invisible {
   opacity: 0;
   pointer-events: none;
@@ -49,8 +47,12 @@ po-toaster {
   pointer-events: auto;
 }
 
-.po-toaster-icon {
+.po-toaster-icon-default {
   padding: var(--spacing-sm);
+}
+
+.po-toaster-decoration {
+  width: 0.25rem;
 }
 
 .po-toaster-icon po-icon {
@@ -65,8 +67,10 @@ po-toaster {
 }
 
 .po-toaster-message {
-  @apply --font-toaster-message;
+  color: var(--font-color);
+  font-family: var(--font-family);
 
+  line-height: 150%;
   padding-top: var(--spacing-xs);
   padding-bottom: var(--spacing-xs);
   padding-left: var(--spacing-sm);
@@ -221,5 +225,100 @@ po-toaster {
   .po-toaster .po-button {
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
+  }
+}
+
+/* TOASTER INLINE STYLE */
+
+.po-toaster-inline {
+  position: initial;
+  width: 100%;
+  justify-content: flex-start;
+  z-index: 1000;
+  --shadow: none;
+}
+
+po-toaster .po-toaster-inline:not([hidden]) {
+  display: flex;
+}
+po-toaster .po-toaster-inline[hidden] {
+  display: none;
+}
+
+.po-toaster-inline .po-toaster-decoration {
+  width: 0.25rem;
+  padding: 0;
+}
+
+/* ICON */
+.po-toaster-inline .po-toaster-inline-icon {
+  padding: var(--spacing-sm);
+  font-size: var(--font-size-lg);
+  color: var(--color-icon);
+}
+
+.po-toaster-inline.po-toaster-warning .po-toaster-inline-icon {
+  color: var(--color-icon-warning);
+}
+
+.po-toaster-inline .po-toaster-inline-icon i {
+  border-radius: 50%;
+}
+.po-toaster-inline .po-toaster-inline-icon i.ph {
+  padding: 0.25rem;
+  font-size: var(--font-size-default);
+  display: flex;
+}
+
+.po-toaster-inline.po-toaster-success .po-toaster-inline-icon i {
+  background: var(--color-success);
+}
+.po-toaster-inline.po-toaster-warning .po-toaster-inline-icon i {
+  background: var(--color-warning);
+}
+.po-toaster-inline.po-toaster-info .po-toaster-inline-icon i {
+  background: var(--color-info);
+  transform: rotate(180deg);
+}
+
+.po-toaster-inline.po-toaster-error .po-toaster-inline-icon i {
+  background: var(--color-error);
+}
+
+/* ACTIONS */
+.po-toaster-inline .po-toaster-actions {
+  padding: var(--spacing-xs) 0;
+  z-index: 1;
+}
+.po-toaster-inline .po-toaster-actions:last-child {
+  margin-right: var(--spacing-xs);
+}
+
+.po-toaster-inline .po-toaster-actions .po-toaster-message {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-md);
+  text-align: left;
+}
+
+.po-toaster-inline .po-toaster-actions .po-toaster-message .po-toaster-support-message {
+  color: var(--font-color-support);
+  font-weight: var(--font-weight-normal);
+}
+
+.po-toaster-inline .po-button {
+  margin: 0;
+  border: none;
+}
+
+@media screen and (max-width: 960px) {
+  .po-toaster-inline .po-toaster-actions {
+    display: flex;
+  }
+
+  .po-toaster-inline .po-toaster-actions .po-toaster-action {
+    display: flex;
+    margin-top: 0;
   }
 }

--- a/src/css/themes/po-theme-default.css
+++ b/src/css/themes/po-theme-default.css
@@ -1929,6 +1929,10 @@ po-toaster {
   --color-icon: var(--color-neutral-light-00);
   --shadow: var(--shadow-lg);
 
+  --font-family: var(--font-family-theme);
+  --font-color: var(--color-neutral-dark-90);
+  --font-color-support: var(--color-neutral-dark-80);
+
   /* Success */
   --color-success: var(--color-feedback-positive-base);
   --background-success: var(--color-feedback-positive-lightest);


### PR DESCRIPTION
Criar componente po-toaster e modo `inline` para mostrar componente diretamente no DOM. Componente também é utilizado pelo po-notification com o modo `alert`

fixes DTHFUI-8864