### PR TITLE
fix(toaster): corrige z-index e cor ícone warning no tema dark

### DIFF
--- a/src/css/services/po-notification/po-toaster/po-toaster.css
+++ b/src/css/services/po-notification/po-toaster/po-toaster.css
@@ -234,7 +234,7 @@ po-toaster {
   position: initial;
   width: 100%;
   justify-content: flex-start;
-  z-index: 1000;
+  z-index: 0;
   --shadow: none;
 }
 


### PR DESCRIPTION
Foi corrigido o z-index do po-toaster para não ficar sobreposto a outros componentes e a cor do ícone do tipo `warning` para cor escura no tema dark

fixes DTHFUI-9230