### PR TITLE
fix(tabs): corrige posicionamento do dropdown

### DIFF
--- a/src/css/components/po-tabs/po-tabs.css
+++ b/src/css/components/po-tabs/po-tabs.css
@@ -1,5 +1,11 @@
+po-page-default .po-tabs-container {
+  overflow: initial;
+  position: relative;
+}
+
 .po-tabs-container {
   overflow: hidden;
+  position: initial;
 }
 
 .po-tabs-header {


### PR DESCRIPTION
Foi realizado uma correção no posicionamento do dropdown. (Ao utilizar o po-tabs com tabs agrupadas pelo dropdown o listbox não abre na posição correta estando dentro de um po-page-default)

fixes DTHFUI-9361