### PR TITLE
fix(combo): ajusta tamanho do componente no system grid

### DIFF
--- a/src/css/components/po-field/po-combo/po-combo.css
+++ b/src/css/components/po-field/po-combo/po-combo.css
@@ -224,3 +224,71 @@ po-combo.ng-invalid.ng-dirty
 po-combo .po-field-container-content {
   display: inline-table;
 }
+
+po-combo.po-md-1,
+po-combo.po-md-2 {
+  --min-width: 0px;
+}
+
+po-combo.po-md-1 .po-combo-input.po-input-icon-right {
+  padding-right: 0px;
+}
+
+po-combo.po-md-1 .po-loading,
+po-combo.po-md-2 .po-loading {
+  width: calc(16.5rem / 4.75);
+}
+
+@media (min-width: 141px) and (max-width: 160px) {
+  po-combo.po-md-1 .po-loading,
+  po-combo.po-md-2 .po-loading,
+  po-combo.po-md-3 .po-loading,
+  po-combo.po-md-4 .po-loading,
+  po-combo.po-md-5 .po-loading,
+  po-combo.po-md-6 .po-loading,
+  po-combo.po-md-7 .po-loading,
+  po-combo.po-md-8 .po-loading,
+  po-combo.po-md-9 .po-loading,
+  po-combo.po-md-10 .po-loading,
+  po-combo.po-md-11 .po-loading,
+  po-combo.po-md-12 .po-loading {
+    width: calc(16.5rem / 2.75);
+  }
+}
+
+@media (min-width: 161px) and (max-width: 480px) {
+  po-combo.po-md-1 .po-loading,
+  po-combo.po-md-2 .po-loading,
+  po-combo.po-md-3 .po-loading,
+  po-combo.po-md-4 .po-loading,
+  po-combo.po-md-5 .po-loading,
+  po-combo.po-md-6 .po-loading,
+  po-combo.po-md-7 .po-loading,
+  po-combo.po-md-8 .po-loading,
+  po-combo.po-md-9 .po-loading,
+  po-combo.po-md-10 .po-loading,
+  po-combo.po-md-11 .po-loading,
+  po-combo.po-md-12 .po-loading {
+    width: calc(16.5rem / 2);
+  }
+}
+
+@media (min-width: 481px) and (max-width: 939px) {
+  po-combo.po-md-1 .po-loading,
+  po-combo.po-md-2 .po-loading {
+    width: calc(16.5rem / 6.75);
+  }
+}
+
+@media (min-width: 940px) and (max-width: 1200px) {
+  po-combo.po-md-1 .po-loading,
+  po-combo.po-md-2 .po-loading {
+    width: calc(16.5rem / 4.75);
+  }
+}
+
+@media (min-width: 426px) and (max-width: 1200px) {
+  po-combo.po-md-1 .po-field-icon-container-left {
+    display: none;
+  }
+}

--- a/src/css/components/po-field/po-multiselect/po-multiselect.css
+++ b/src/css/components/po-field/po-multiselect/po-multiselect.css
@@ -86,3 +86,22 @@ po-multiselect.ng-invalid.ng-dirty .po-multiselect-input {
 po-multiselect.ng-invalid.ng-dirty .po-multiselect-input .po-field-icon-container-right .po-icon-input {
   color: var(--color-error);
 }
+
+po-multiselect.po-md-1:has(po-loading) .po-loading-md,
+po-multiselect.po-md-2:has(po-loading) .po-loading-md {
+  width: calc(16.5rem / 6);
+}
+
+@media (min-width: 141px) and (max-width: 160px) {
+  po-multiselect.po-md-1:has(po-loading) .po-loading-md,
+  po-multiselect.po-md-2:has(po-loading) .po-loading-md {
+    width: calc(16.5rem / 2.75);
+  }
+}
+
+@media (min-width: 161px) and (max-width: 480px) {
+  po-multiselect.po-md-1:has(po-loading) .po-loading-md,
+  po-multiselect.po-md-2:has(po-loading) .po-loading-md {
+    width: calc(16.5rem / 2);
+  }
+}


### PR DESCRIPTION

DTHFUI - 8490 - Po-combo com 1 coluna.

* Aplicado também ao po-multiselect

Ajusta o tamanho do po-combo e po-multiselect para casos em que estão inseridos em um system grid.

Qual o comportamento atual?
Quando se tem um po-combo inserido em um sistema de grid, o seu tamanho, pode ultrapassar os limites de espaçamento entre uma coluna e outra dependendo do tamanho de tela e do tamanho que estiver estipulado para a coluna que contém o po-combo. No casos reportado da issue acima o problema de sobreposição acontecia quando o po-combo estava com espaçamento de "po-md-1", no caso, tamanho para 1 coluna. Além de sua largura visivelmente ultrapassar o limite da coluna em que está inserido, dava a impressão de que outro componente, da coluna ao lado, estivesse invadindo a respectiva área.

Outro problema apontado foi o dimensionamento do loading que estava também ultrapassando os limites do overlay contido no po-combo.

Os mesmos problemas apontados acima observei também no po-multiselect.

Qual o novo comportamento?
Ajustado comportamento do po-combo para respeitar o limite da coluna ao qual está inserido.
Ajustado loading para ficar limitado a largura do overlay.

Simulação
Alterar o dimensionamento da tela através do devTools do navegador para observar que pelos diversos tamanhos de dispositivos o componente deverá estar adequado.
[app.zip](https://github.com/user-attachments/files/16474627/app.zip)