### PR TITLE
feat(dynamic-view): adiciona propriedade p-text-wrap

### DIFF
--- a/src/css/components/po-info/po-info.css
+++ b/src/css/components/po-info/po-info.css
@@ -29,12 +29,17 @@
     color: var(--color-info-color-text-value);
     display: block;
     min-height: 24px;
+    word-break: break-word;
 
     &-horizontal {
       display: table-cell;
       margin-top: 0;
       /* Usado por conta do espaçamento do grid system */
       padding: 0 !important;
+    }
+
+    &-pre {
+      white-space: pre-wrap;
     }
   }
 }


### PR DESCRIPTION
O componente po-dynamic-view não preserva as quebras de linha dos dados recebidos da API. Adiciona a propriedade `p-text-wrap` para garantir que as quebras de linha (`\n`) sejam respeitadas na visualização dos dados.

Fixes DTHFUI-9446