### PR TITLE
fix(toolbar): corrige posicionamento do popup ao abrir notificação

### DIFF
--- a/src/css/components/po-toolbar/po-toolbar.css
+++ b/src/css/components/po-toolbar/po-toolbar.css
@@ -138,3 +138,7 @@
     padding-right: 8px;
   }
 }
+
+po-toolbar .po-popup {
+  width: max-content;
+}


### PR DESCRIPTION
Foi corrigido o posicionamento ao abrir a popup da notificação no toolbar, tanto em tamanhos de tela pequena, quanto grande.

fixes DTHFUI-9586 / issue 2172