### PR TITLE
fix(table): possibilita desabilitar a propriedade p-virtual-scroll

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -174,6 +174,12 @@
   flex-direction: column;
 }
 
+.po-table-container-overflow {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: auto;
+}
+
 .po-table-container-fixed-inner {
   height: 100%;
   overflow-y: hidden;


### PR DESCRIPTION
**PO-Table**

**DTHFUI-9499**

**Qual o comportamento atual?**
Identificada incompatibilidade do virtual scroll com linhas de alturas indefinidas.

**Qual o novo comportamento?**
Possibilita desabilitar a propriedade p-virtual-scroll.
