### PR TITLE
fix(table): corrige coluna do tipo link

### DIFF
--- a/src/css/components/po-table/po-table-column-link/po-table-column-link.css
+++ b/src/css/components/po-table/po-table-column-link/po-table-column-link.css
@@ -1,5 +1,7 @@
 .po-table-link {
-  display: inline-block;
+  display: inline;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .po-table-link-disabled {


### PR DESCRIPTION
**TABLE**

**DTHFUI-9883**
_____________________________________________________________________________

**Qual o comportamento atual?**
 Ao utilizar o po-table com uma coluna do tipo link, caso os dados não fiquem totalmente visíveis por conta da largura da coluna, o ellipsis não é aplicado como é aplicado nas demais colunas.

**Qual o novo comportamento?**
Ao utilizar o po-table com uma coluna do tipo link o ellipsis é aplicado como é aplicado nas demais colunas.

**Simulação**
[app-9883.zip](https://github.com/user-attachments/files/17243614/app-9883.zip)


