### PR TITLE
fix(table): corrige coluna do tipo link

### DIFF
--- a/src/css/components/po-table/po-table-column-link/po-table-column-link.css
+++ b/src/css/components/po-table/po-table-column-link/po-table-column-link.css
@@ -1,5 +1,7 @@
 .po-table-link {
-  display: inline-block;
+  display: inline;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .po-table-link-disabled {


### PR DESCRIPTION
corrige coluna do tipo link exibindo `ellipsis` caso dados não ficarem totalmente visíveis.

fixes DTHFUI-9883