### PR TITLE
fix(page-login): corrige literals rememberUser

### DIFF
--- a/src/css/components/po-field/po-switch/po-switch.css
+++ b/src/css/components/po-field/po-switch/po-switch.css
@@ -111,6 +111,10 @@
   width: inherit;
 }
 
+po-page-login .po-switch {
+  justify-content: end;
+}
+
 @media print {
   .po-switch-container {
     print-color-adjust: exact;


### PR DESCRIPTION
Corrige literals `rememberUser` que não estava aparecendo ao lado do switch

fixes DTHFUI-9751