### PR TITLE
fix(multiselect): ajusta a referência de altura

### DIFF
--- a/src/css/components/po-field/po-multiselect/po-multiselect.css
+++ b/src/css/components/po-field/po-multiselect/po-multiselect.css
@@ -14,7 +14,7 @@
   display: flex;
   flex-wrap: wrap;
   line-height: normal;
-  min-height: 2.75em;
+  min-height: 2.75rem;
 
   padding-block: var(--spacing-xs);
   overflow: hidden;


### PR DESCRIPTION
DTHFUI-9649

Comportamento atual:
Componente tinha a propriedade min-height: 2.75em o que define a altura baseado no elemento pai ao qual o elemento está vinculado;

Novo comportamento:
Alterado para a unidade "rem" (min-height: 2.75rem), que define a altura baseado no elemento raiz;