### PR TITLE
feat(richtext): inclusão propriedade para ocultar botões do toolbar

### DIFF
--- a/src/css/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.css
+++ b/src/css/components/po-field/po-rich-text/po-rich-text-body/po-rich-text-body.css
@@ -19,7 +19,7 @@
   @apply --font-rich-text;
   background-color: var(--color-rich-text-body-background-color);
   border: var(--border-rich-text-body-border);
-  border-radius: 3px 3px 0 0;
+  border-radius: var(--border-radius-md) var(--border-radius-md) 0 0;
   box-shadow: var(--shadow-rich-text-body-box-shadow);
   max-height: var(--rich-text-body-max-height);
   min-height: var(--rich-text-body-min-height);
@@ -27,6 +27,10 @@
   overflow-y: auto;
   padding: 10px 16px;
   width: 100%;
+}
+
+.po-rich-text-body:only-child {
+  border-radius: var(--border-radius-md);
 }
 
 .po-rich-text-body b {

--- a/src/css/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.css
+++ b/src/css/components/po-field/po-rich-text/po-rich-text-toolbar/po-rich-text-toolbar.css
@@ -16,14 +16,14 @@
 .po-rich-text-toolbar {
   background-color: var(--color-rich-text-toolbar-background-color);
   border: var(--border-rich-text-toolbar-border);
-  border-radius: 0 0 3px 3px;
+  border-radius: 0 0 var(--border-radius-md) var(--border-radius-md);
   border-top: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 1em 0.75em;
+  gap: 1rem 0.75rem;
   min-height: var(--rich-text-toolbar-min-height);
   min-width: var(--rich-text-toolbar-min-width);
-  padding: 1em;
+  padding: 1rem;
   width: 100%;
 }
 
@@ -68,7 +68,7 @@
 
 /* Altera o tamanho do ícone dos po-buttons para respeitar o tamanho definido pela UX */
 .po-rich-text-toolbar .po-button-group .po-icon {
-  font-size: 1.5em;
+  font-size: 1.5rem;
 }
 
 .po-rich-text-toolbar-color-picker-input {


### PR DESCRIPTION
Implementação da propriedade 'p-hide-toolbar-actions'. Com essa propriedade, será possível passar os botões do toolbar que serão ocultados do toolbar. Se for passado todas as opções existentes ('color', 'align', 'format', 'list', 'link', 'media'), a toolbar não será exibida.

fixes DTHFUI-9923