### PR TITLE
feat(chart): inclusão propriedade `p-data-label` para chart tipo `line`

### DIFF
--- a/src/css/components/po-chart/po-chart.css
+++ b/src/css/components/po-chart/po-chart.css
@@ -170,6 +170,25 @@ po-chart-legend {
   fill: var(--color-chart-line-point-fill);
 }
 
+.po-chart-line-path-group {
+  opacity: 1;
+}
+
+.po-chart-line-path-blur {
+  opacity: 0.25;
+  transition: opacity 0.1s ease-in;
+}
+
+.po-chart-series-point-text {
+  font-size: 12px;
+  fill: var(--color-neutral-dark-95);
+}
+
+.po-chart-series-point-text-rect {
+  fill: var(--color-neutral-light-00);
+  fill-opacity: 0.7;
+}
+
 @media screen and (min-width: 1024px) {
   .po-chart-header {
     padding-bottom: 24px;


### PR DESCRIPTION
Implementação da propriedade 'p-data-label', onde é possível passar a propriedade `fixed`. Com essa propriedade (fixed=tue), irar alterar o grafico do tipo line.
- O valor da series ficar sendo exibido fixado com uma background transparente.
- Não será mostrado o tooltip ao hover do bullet.
- Será adicionado uma opacidade a todas outras series quando selecionado uma delas.
- O hover da serie ficará ate selecionar outra ou sair do gráfico.

fixes DTHFUI-10134