### PR TITLE
feat(fields): adiciona limite na exibição de mensagens de erro

### DIFF
--- a/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.css
+++ b/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.css
@@ -82,3 +82,12 @@ po-field-container-bottom .po-field-container-bottom {
   display: block;
   margin-left: 24px;
 }
+
+.po-field-error-limit {
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  box-orient: vertical;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.html
+++ b/src/css/components/po-field/po-field-container/po-field-container-bottom/po-field-container-bottom.html
@@ -1,6 +1,6 @@
 <div class="po-field-container-bottom">
-  <span class="po-field-container-bottom-text-error">
-    <span class="po-icon po-icon-warning po-field-container-icon-error"></span>
-    Mensagem de erro
-  </span>
+  <div class="po-field-container-bottom-text-error">
+    <span class="ph ph-warning-circle po-field-container-icon-error"></span>
+    <span class="po-field-error-message po-field-error-limit" p-tooltip="Mensagem de erro">Mensagem de erro</span>
+  </div>
 </div>


### PR DESCRIPTION
Adiciona as propriedades:
	- `p-error-limit` no `po-field-container-bottom`
	- `p-field-error-limit` nos componentes `po-checkbox-group`, `po-combo`, `po-datepicker`, `po-datepicker-range`, `po-decimal`, `po-email`, `po-input`, `po-login`, `po-lookup`, `po-multiselect`, `po-number`, `po-password`, `po-radio group`, `po-rich-text`, `po-select`, `po-textarea`, `po-url`
	- `errorLimit` na interface para o componente `po-dynamic-form-field` utilizado para os componentes `po-datepicker`, `po-input`, `po-number`, `po-decimal`, `po-password`, `po-datepicker-range`, `po-select`, `po-checkbox-group`, `po-radio-group`, `po-multiselect`, `po-combo`, `po-lookup`, `po-textarea`

- no componente `po-field-container-bottom`, a propriedade permite limitar a exibição da mensagem de erro a duas linhas e exibir um tooltip com o texto completo.

Essa funcionalidade permite uma exibição mais compacta da mensagem de erro, com a opção de visualizar o conteúdo completo (via tooltip) ao passar o mouse sobre o erro.

Fixes DTHFUI-10517