### PR TITLE
feat(tabs): adiciona o token --background-item-default

### DIFF
--- a/src/css/components/po-tabs/po-tab-button/po-tab-button.css
+++ b/src/css/components/po-tabs/po-tab-button/po-tab-button.css
@@ -34,6 +34,8 @@
   display: inline-flex;
   text-align: center;
   width: 100%;
+  background-color: var(--background-item-default);
+  border-radius: var(--border-radius);
 }
 
 .po-tab-button-default:not(.po-tab-button-disabled, .po-tab-dropdown-content):hover {

--- a/src/css/themes/po-theme-default.css
+++ b/src/css/themes/po-theme-default.css
@@ -1426,6 +1426,8 @@ po-tab-button {
   --color: var(--color-action-default);
   --border-radius: var(--border-radius-md);
 
+  --background-item-default: var(--color-transparent);
+
   --background-item-selected: var(--color-brand-01-lightest);
 
   --color-hover: var(--color-brand-01-darkest);


### PR DESCRIPTION
O componente po-tabs implementa apenas o token --background, que altera a cor de fundo do componente por inteiro. Adiciona o token --background-item-default para permitir a customização da cor de fundo do item padrão separadamente da cor de fundo de todo o po-tabs.

Fixes: DTHFUI-10947