### PR TITLE
feat(label): implementa quebra de linha para textos do requirement

### DIFF
--- a/src/css/components/po-label/po-label.css
+++ b/src/css/components/po-label/po-label.css
@@ -1,5 +1,7 @@
 po-label {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
 }
 
 .po-label {
@@ -31,6 +33,8 @@ po-label {
   color: var(--text-color-required);
   font-size: var(--font-size-required);
   line-height: var(--line-height-required);
+  white-space: normal;
+  word-break: break-word;
 }
 
 .po-label-requirement::after {


### PR DESCRIPTION
Implementa melhoria para resolver o problema onde os textos "(Obrigatório)" ou "(Opcional)" não quebravam linha em containers pequenos, causando overflow. A solução utilizada abrange componentes de formulário como:
- po-input
- po-dynamic-form
- demais componentes com po-label

Fixes DTHFUI-10940