### PR TITLE
refactor(badge,container): adiciona estilos para CSP

### DIFF
--- a/src/css/components/po-badge/po-badge.css
+++ b/src/css/components/po-badge/po-badge.css
@@ -1,3 +1,8 @@
+po-badge {
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .po-badge-default {
   background-color: var(--background-color);
 }

--- a/src/css/components/po-container/po-container.css
+++ b/src/css/components/po-container/po-container.css
@@ -45,3 +45,7 @@
 .po-container-no-padding {
   padding: 0;
 }
+
+po-page-job-scheduler .po-container {
+  overflow-y: unset;
+}


### PR DESCRIPTION
Adiciona seletor de elemento 'po-badge' com display e vertical-align no po-badge.css, permitindo remover styles inline do decorator Angular.

Adiciona regra contextual para po-page-job-scheduler no po-container.css, garantindo overflow-y: unset quando po-container é usado dentro do job scheduler.

Essas alterações permitem que o po-angular remova @Component({ styles }) dos componentes core, eliminando tags <style> inline que violam CSP restritiva (style-src 'self').

Fixes DTHFUI-12623