### PR TITLE
feat(page-default): adiciona propriedade p-helper no subtítulo

### DIFF
--- a/src/css/components/po-helper/po-helper.css
+++ b/src/css/components/po-helper/po-helper.css
@@ -62,3 +62,19 @@ po-helper:has(.po-helper-disabled) {
   cursor: not-allowed;
   pointer-events: none;
 }
+
+.po-helper-content-text {
+  display: inline;
+}
+
+.po-helper-text-bold {
+  font-weight: var(--font-weight-bold);
+}
+
+.po-helper-text-italic {
+  font-style: italic;
+}
+
+.po-helper-text-underline {
+  text-decoration: underline;
+}

--- a/src/css/components/po-page/po-page-header/po-page-header.css
+++ b/src/css/components/po-page/po-page-header/po-page-header.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   align-items: flex-start;
   flex-wrap: wrap;
+  gap: var(--spacing-xs);
 }
 
 .po-page-header-title-container {
@@ -43,9 +44,12 @@
 .po-page-header-subtitle {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-normal);
-  line-height: var(--line-height-2xs);
+  line-height: var(--line-height-sm);
   color: var(--color-neutral-dark-70);
   letter-spacing: var(--letter-spacing-auto);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 
 .po-page-header-actions {


### PR DESCRIPTION
Adiciona a propriedade 'p-helper' para exibição de mensagens de ajuda.
Permite a formatação de texto no conteúdo do helper utilizando as tags HTML básicas: ```<b>, <strong>, <i>, <em> e <u>```.

Fixes DTHFUI-13013