### PR TITLE
feat(page): suporta tags HTML básicas no subtitle

### DIFF
--- a/src/css/commons/index.css
+++ b/src/css/commons/index.css
@@ -11,3 +11,4 @@
 @import './po-scrollbar/po-scrollbar.css';
 @import './po-shadow/po-shadow.css';
 @import './po-spacing';
+@import './po-text-formatting/po-text-formatting.css';

--- a/src/css/commons/po-text-formatting/po-text-formatting.css
+++ b/src/css/commons/po-text-formatting/po-text-formatting.css
@@ -1,0 +1,11 @@
+.po-text-bold {
+  font-weight: var(--font-weight-bold);
+}
+
+.po-text-italic {
+  font-style: italic;
+}
+
+.po-text-underline {
+  text-decoration: underline;
+}

--- a/src/css/components/po-helper/po-helper.css
+++ b/src/css/components/po-helper/po-helper.css
@@ -66,15 +66,3 @@ po-helper:has(.po-helper-disabled) {
 .po-helper-content-text {
   display: inline;
 }
-
-.po-helper-text-bold {
-  font-weight: var(--font-weight-bold);
-}
-
-.po-helper-text-italic {
-  font-style: italic;
-}
-
-.po-helper-text-underline {
-  text-decoration: underline;
-}


### PR DESCRIPTION
Permite a formatação de texto no conteúdo do subtitle utilizando as tags HTML básicas: <b>, <strong>, <i>, <em> e <u>.

Fixes DTHFUI-13081