### PR TITLE
fix(table): corrige tabela piscando ao realizar scroll

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -172,6 +172,23 @@
   overflow-x: auto;
 }
 
+.po-table-virtual-scroll-wrapper {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.po-table-header-virtual-scroll {
+  background-color: var(--background-color-headline);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.po-table-header-relative {
+  position: relative;
+  z-index: 2;
+}
+
 .po-table .po-table-row-active td {
   background-color: var(--background-color-selected);
   color: var(--color-actived);


### PR DESCRIPTION
Tabela com muitos itens ao realizar o scroll acontece flickering (piscar) em toda tabela. Extrai o <thead> de dentro do 'cdk-virtual-scroll-viewport' mantendo a visualização da tag ao realizar o scroll.

Fix: DTHFUI-13182