### PR TITLE
fix(list-view): adiciona padding-left no título simples com checkbox

### DIFF
--- a/src/css/components/po-list-view/po-list-view.css
+++ b/src/css/components/po-list-view/po-list-view.css
@@ -81,7 +81,8 @@
   padding: var(--po-density-content-padding, var(--spacing-xs) var(--default-spacing-sm, var(--spacing-md)));
 }
 
-.po-list-view-select + .po-list-view-title-link {
+.po-list-view-select + .po-list-view-title-link,
+.po-list-view-select ~ .po-list-view-title-no-link {
   padding-left: 0.5rem;
   vertical-align: bottom;
 }


### PR DESCRIPTION
Aplica o mesmo espaçamento de 0.5rem que o título com link já possuía quando precedido pelo checkbox de seleção.

Fixes DTHFUI-11808