### PR TITLE
fix(timepicker): esconde ":" ao usar placeholder ou formato 12h

### DIFF
--- a/src/css/components/po-field/po-timepicker/po-timepicker.css
+++ b/src/css/components/po-field/po-timepicker/po-timepicker.css
@@ -100,6 +100,12 @@ po-timepicker {
   user-select: none;
 }
 
+.po-timepicker-field-separator-hidden {
+  width: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
 .po-timepicker-field-placeholder .po-timepicker-field-separator {
   color: var(--text-color-placeholder);
 }


### PR DESCRIPTION
Esconde os separadores ":" quando houver placeholder ou formato de 12 horas.

Fixes: DTHFUI-13331