### PR TITLE
fix(table): corrige tabela piscando ao realizar scroll - Proposta sem CDK

### DIFF
--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -176,6 +176,23 @@
   overflow-x: auto;
 }
 
+.po-table-virtual-scroll-wrapper {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.po-table-header-virtual-scroll {
+  background-color: var(--background-color-headline);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.po-table-header-relative {
+  position: relative;
+  z-index: 2;
+}
+
 .po-table .po-table-row-active td {
   background-color: var(--background-color-selected);
   color: var(--color-actived);

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -183,23 +183,6 @@
   height: 100%;
 }
 
-.po-table-virtual-scroll-wrapper {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.po-table-header-virtual-scroll {
-  background-color: var(--background-color-headline);
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.po-table-header-relative {
-  position: relative;
-  z-index: 2;
-}
-
 .po-table .po-table-row-active td {
   background-color: var(--background-color-selected);
   color: var(--color-actived);
@@ -715,10 +698,6 @@ span.po-table-header-icon-ascending svg {
 
 .po-table-row-template-container {
   max-width: 1rem;
-}
-
-.po-table-row-template-hidden {
-  display: none;
 }
 
 .po-table-header-flex po-icon,

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -176,6 +176,13 @@
   overflow-x: auto;
 }
 
+.po-table-virtual-viewport {
+  overflow-y: auto;
+  overflow-x: auto;
+  width: 100%;
+  height: 100%;
+}
+
 .po-table-virtual-scroll-wrapper {
   display: flex;
   flex-direction: column;
@@ -200,6 +207,27 @@
 
 .po-table.po-table-striped > tbody:nth-child(odd) tr:first-child:not(.po-table-row-active) td,
 .po-table.po-table-striped .po-table-master-detail > tbody tr:nth-child(odd):not(.po-table-row-active) td {
+  background-color: var(--background-striped-color);
+}
+
+/* Virtual scroll: borda inferior em cada row (exceto a última) dentro de tbody único */
+.po-table-virtual-viewport .po-table tbody tr.po-table-row:not(:last-of-type) td {
+  border-bottom: solid;
+  border-bottom-color: var(--color-line);
+  border-bottom-width: var(--border-width-sm);
+}
+
+/* Virtual scroll: remove borda quando striped está ativo */
+.po-table-virtual-viewport .po-table.po-table-striped tbody tr.po-table-row td {
+  border-bottom: none;
+}
+
+/* Virtual scroll: efeito zebrado baseado em rows (nth-of-type em tr) */
+.po-table-virtual-viewport
+  .po-table.po-table-striped
+  tbody
+  tr.po-table-row:nth-of-type(odd):not(.po-table-row-active)
+  td {
   background-color: var(--background-striped-color);
 }
 
@@ -682,6 +710,10 @@ span.po-table-header-icon-ascending svg {
 
 .po-table-row-template-container {
   max-width: 1rem;
+}
+
+.po-table-row-template-hidden {
+  display: none;
 }
 
 .po-table-header-flex po-icon,

--- a/src/css/components/po-table/po-table.css
+++ b/src/css/components/po-table/po-table.css
@@ -210,11 +210,16 @@
   background-color: var(--background-striped-color);
 }
 
-/* Virtual scroll: borda inferior em cada row (exceto a última) dentro de tbody único */
-.po-table-virtual-viewport .po-table tbody tr.po-table-row:not(:last-of-type) td {
+/* Virtual scroll: borda inferior em cada row de dados */
+.po-table-virtual-viewport .po-table tbody tr.po-table-row td {
   border-bottom: solid;
   border-bottom-color: var(--color-line);
   border-bottom-width: var(--border-width-sm);
+}
+
+/* Remove borda da última row do dataset (marcada via classe no template) */
+.po-table-virtual-viewport .po-table tbody tr.po-table-row.po-table-row-last td {
+  border-bottom: none;
 }
 
 /* Virtual scroll: remove borda quando striped está ativo */


### PR DESCRIPTION
Implementa virtualização manual de linhas no po-table usando padding rows (spacer top/bottom), eliminando a dependência do CdkVirtualScrollViewport.

**Principais pontos:**

1. Renderiza apenas os itens visíveis + buffer via slice do array (vsVisibleItems)
2. Spacer rows no topo/fundo mantêm a scrollbar proporcional ao total de itens
3. Header sticky via CSS nativo (position: sticky; top: 0)
4. Scroll listener fora do NgZone (sem disparar change detection a cada evento)
5. requestAnimationFrame para coalescer scroll events (1 update/frame)